### PR TITLE
Update sysctl and fix NetworkManager

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -354,7 +354,7 @@ ubtu22cis_rule_5_6: true
 ubtu22cis_rule_5_7: true
 
 # Section 6 Fixes
-# Section is Systme Maintenance (System File Permissions and User and Group Settings)
+# Section is System Maintenance (System File Permissions and User and Group Settings)
 ubtu22cis_rule_6_1_1: true
 ubtu22cis_rule_6_1_2: true
 ubtu22cis_rule_6_1_3: true

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -72,6 +72,7 @@
       state: present
   when:
       - ubtu22cis_rule_3_1_2
+      - ubtu22cis_install_network_manager
       - not ubtu22cis_system_is_container
       - "'network-manager' not in ansible_facts.packages"
 
@@ -157,7 +158,6 @@
       state: present
   when:
       - ubtu22cis_rule_6_2_6
-      - ubtu22cis_install_network_manager
       - "'acl' not in ansible_facts.packages"
 
 - name: "PRELIM | Gather UID 0 accounts other than root"


### PR DESCRIPTION
**Overall Review of Changes:**
* The check for NetworkManager is applied to the wrong task, move it to the correct one.
* Fix some typo's

**How has this been tested?:**
* I've run this role against my own Ubuntu 22.04 installation, without rsyslog, without firewall and with systemd-timesyncd as NTP.