### PR TITLE
fix: auditd systemctl reload

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -121,9 +121,11 @@
       - auditd_immutable_check.stdout == '1'
 
 - name: Restart auditd
-  ansible.builtin.shell: service auditd restart
-  args:
-      warn: false
+  ansible.builtin.systemd:
+    daemon_reload: true
+    name: auditd
+    enabled: true
+    state: restarted
   when:
       - audit_rules_updated.changed or
         rule_4_1_2_1.changed or


### PR DESCRIPTION
**Overall Review of Changes:**
Fixed an error thrown when executing playbook as args warn is not a valid argument.

**Issue Fixes:**
- Corrected using a shell directive to use the built-in systemd to reload the auditd service.

**Enhancements:**
- Use the correct ansible directive.

**How has this been tested?:**
Tested by booting up an ubuntu-2204-minimal-jammy image and executing the playbook. Had to pre-install UFW otherwise another error would be thrown.
