### PR TITLE
Fix typo for systemctl handler name

### DIFF
--- a/tasks/section_1/cis_1.5.x.yml
+++ b/tasks/section_1/cis_1.5.x.yml
@@ -101,7 +101,7 @@
             owner: root
             group: root
             mode: '0644'
-        notify: Reload_systemctl
+        notify: Reload systemctl
 
       - name: "1.5.4 | PATCH | Ensure core dumps are restricted | coredump.conf"
         ansible.builtin.lineinfile:


### PR DESCRIPTION
**Overall Review of Changes:**
A handler was renamed a few months ago and a task that calls that handler was not renamed, this the playbook will error when running:

```
error:

TASK [/Users/tperrone/git/github/UBUNTU22-CIS : 1.5.4 | PATCH | Ensure core dumps are restricted | sysctl.conf] ***
ERROR! The requested handler 'Reload_systemctl' was not found in either the main handlers list nor in the listening handlers list
```

**Issue Fixes:**
Based on the last commit hash on `devel` [https://github.com/ansible-lockdown/UBUNTU22-CIS/blob/291b7aadc12a057fc8b819af422ab199f0b0cf56/tasks/section_1/cis_1.5.x.yml#L104](https://github.com/ansible-lockdown/UBUNTU22-CIS/blob/291b7aadc12a057fc8b819af422ab199f0b0cf56/tasks/section_1/cis_1.5.x.yml#L104) the notify arguments attempts to call `Reload_systemctl` however the handler was renamed a few months ago and the `_` for the naming was removed here: [https://github.com/ansible-lockdown/UBUNTU22-CIS/commit/a0fc4fa94902b7aa2658431424e1e0036e5791a5#diff-67da321934d1a76cffaa1feed7ef7899327b68724357089bf6eeb4af62103715R12](https://github.com/ansible-lockdown/UBUNTU22-CIS/commit/a0fc4fa94902b7aa2658431424e1e0036e5791a5#diff-67da321934d1a76cffaa1feed7ef7899327b68724357089bf6eeb4af62103715R12)

**Enhancements:**
task runs without error

**How has this been tested?:**
Tested with latest ubuntu-22-lts-server-minimal.iso installed on proxmox, saw the issue initially running against an AWS ec2 running off latest canonical AMI from May 2023


_Signed-off-by: Trey Perrone <trey.perrone@gmail.com>_