### PR TITLE
Use /bin/true to disable filesystems

### DIFF
--- a/tasks/section_1/cis_1.1.1.x.yml
+++ b/tasks/section_1/cis_1.1.1.x.yml
@@ -6,7 +6,7 @@
         ansible.builtin.lineinfile:
             dest: /etc/modprobe.d/cramfs.conf
             regexp: '^(#)?install cramfs(\\s|$)'
-            line: install cramfs /bin/false
+            line: install cramfs /bin/true
             create: true
 
       - name: "1.1.1.1 | PATCH | Ensure mounting of cramfs filesystems is disabled | Disable cramfs"
@@ -30,7 +30,7 @@
         ansible.builtin.lineinfile:
             dest: /etc/modprobe.d/squashfs.conf
             regexp: '^(#)?install squashfs(\\s|$)'
-            line: install squashfs /bin/false
+            line: install squashfs /bin/true
             create: true
 
       - name: "1.1.1.2 | PATCH | Ensure mounting of squashfs filesystems is disabled | Disable squashfs"


### PR DESCRIPTION
**Overall Review of Changes:**

The` /bin/false` command returns non-zero, hence the loader may log this event as an error. To avoid log errors, we should use `/bin/true` instead.

Additionally some compliance testing tools check for the presence of `/bin/true`.

**Issue Fixes:**
Please list (using linking) any open issues this PR addresses

**Enhancements:**
Please list any enhancements/features that are not open issue tickets

**How has this been tested?:**
Tested on Ubuntu 22.04 and ends in same result.