### PR TITLE
Fix regex in lininfile in Ubuntu rule 1.6.1.2

### DIFF
--- a/tasks/section_1/cis_1.6.x.yml
+++ b/tasks/section_1/cis_1.6.x.yml
@@ -28,7 +28,7 @@
       - name: "1.6.1.2 | PATCH | Ensure AppArmor is enabled in the bootloader configuration | Set apparmor settings if none exist"
         ansible.builtin.lineinfile:
             path: /etc/default/grub
-            regexp: '^GRUB_CMDLINE_LINUX'
+            regexp: '^GRUB_CMDLINE_LINUX='
             line: 'GRUB_CMDLINE_LINUX="apparmor=1 security=apparmor {{ ubtu22cis_1_6_1_2_cmdline_settings.stdout }}"'
             insertafter: '^GRUB_'
         when:


### PR DESCRIPTION
There is a missing equals sign, causing incorrect replacement if `GRUB_CMDLINE_LINUX_DEFAULT` is also present in `/etc/default/grub`.

**Overall Review of Changes:**
 Corrects the lineinfile regex for Ubuntu rule 1.6.1.2 by adding a missing equals sign after GRUB_CMDLINE_LINUX.

**Issue Fixes:**
N/A

**Enhancements:**
N/A

**How has this been tested?:**
 Tested on Ubuntu Jammy. Reverted the previous incorrect replacement, then used the fixed playbook to reapply the rule.
