### PR TITLE
fix: PRELIM mont type block failing

### DIFF
--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -19,19 +19,19 @@
   block:
       - name: PRELIM | Capture tmp mount type | discover mount tmp type
         ansible.builtin.shell: systemctl is-enabled tmp.mount
-        register: tmp_mnt_type
+        register: systemctl_tmp_mnt_type
         changed_when: false
-        failed_when: tmp_mnt_type.rc not in [ 0, 1 ]
+        failed_when: systemctl_tmp_mnt_type.rc not in [ 0, 1 ]
 
       - name: PRELIM | Capture tmp mount type | Set fstab
         ansible.builtin.set_fact:
             tmp_mnt_type: fstab
-        when: "'generated' in tmp_mnt_type.stdout"
+        when: "'generated' in systemctl_tmp_mnt_type.stdout"
 
       - name: PRELIM | Capture tmp mount type | Set systemd service
         ansible.builtin.set_fact:
             tmp_mnt_type: tmp_systemd
-        when: "'generated' not in tmp_mnt_type.stdout"
+        when: "'generated' not in systemctl_tmp_mnt_type.stdout"
   when:
       - "'/tmp' in mount_names"
       - ubtu22cis_rule_1_1_2_1 or

--- a/tasks/section_1/cis_1.1.2.x.yml
+++ b/tasks/section_1/cis_1.1.2.x.yml
@@ -38,8 +38,8 @@
   loop_control:
       label: "{{ item.device }}"
   when:
-      - tmp_mnt_type == 'tmp_systemd'
       - item.mount == "/tmp"
+      - tmp_mnt_type == 'tmp_systemd'
       - ubtu22cis_rule_1_1_2_1 or
         ubtu22cis_rule_1_1_2_2 or
         ubtu22cis_rule_1_1_2_3 or

--- a/tasks/section_1/cis_1.1.2.x.yml
+++ b/tasks/section_1/cis_1.1.2.x.yml
@@ -65,24 +65,31 @@
     "1.1.2.2 | PATCH | Ensure nodev option set on /tmp partition | fstab"
     "1.1.2.3 | PATCH | Ensure noexec option set on /tmp partition | fstab"
     "1.1.2.4 | PATCH | Ensure nosuid option set on /tmp partition | fstab"
-  ansible.posix.mount:
-      name: "{{ item.device }}"
-      src: "{{ item.fstype }}"
-      state: present
-      fstype: tmpfs
-      opts: defaults,{% if ubtu22cis_rule_1_1_2_2 %}nodev,{% endif %}{% if ubtu22cis_rule_1_1_2_3 %}noexec,{% endif %}{% if ubtu22cis_rule_1_1_2_4 %}nosuid{% endif %}
-  notify: remount tmp
-  with_items:
-      - "{{ ansible_mounts }}"
-  loop_control:
-      label: "{{ item.device }}"
+  block:
+      - name: |
+          "1.1.2.2 | PATCH | Ensure nodev option set on /tmp partition | fstab"
+          "1.1.2.3 | PATCH | Ensure noexec option set on /tmp partition | fstab"
+          "1.1.2.4 | PATCH | Ensure nosuid option set on /tmp partition | fstab"
+        ansible.posix.mount:
+            name: "{{ item.device }}"
+            src: "{{ item.fstype }}"
+            state: present
+            fstype: tmpfs
+            opts: defaults,{% if ubtu22cis_rule_1_1_2_2 %}nodev,{% endif %}{% if ubtu22cis_rule_1_1_2_3 %}noexec,{% endif %}{% if ubtu22cis_rule_1_1_2_4 %}nosuid{% endif %}
+        notify: remount tmp
+        with_items:
+            - "{{ ansible_mounts }}"
+        loop_control:
+            label: "{{ item.device }}"
+        when:
+            - tmp_mnt_type == 'fstab'
+            - item.mount == "/tmp"
   when:
-      - tmp_mnt_type == 'fstab'
-      - item.mount == "/tmp"
-      - ubtu22cis_rule_1_1_2_1 or
-        ubtu22cis_rule_1_1_2_2 or
-        ubtu22cis_rule_1_1_2_3 or
-        ubtu22cis_rule_1_1_2_4
+    - "'/tmp' in mount_names"
+    - ubtu22cis_rule_1_1_2_1 or
+      ubtu22cis_rule_1_1_2_2 or
+      ubtu22cis_rule_1_1_2_3 or
+      ubtu22cis_rule_1_1_2_4
   tags:
       - level1-server
       - level1-workstation

--- a/tasks/section_1/cis_1.1.2.x.yml
+++ b/tasks/section_1/cis_1.1.2.x.yml
@@ -26,33 +26,40 @@
     "1.1.2.2 | PATCH | Ensure nodev option set on /tmp partition | tmp_systemd"
     "1.1.2.3 | PATCH | Ensure noexec option set on /tmp partition | tmp_systemd"
     "1.1.2.4 | PATCH | Ensure nosuid option set on /tmp partition | tmp_systemd"
-  ansible.builtin.template:
-      src: etc/systemd/system/tmp.mount.j2
-      dest: /etc/systemd/system/tmp.mount
-      owner: root
-      group: root
-      mode: 0644
-  notify: Remount tmp
-  with_items:
-      - "{{ ansible_mounts }}"
-  loop_control:
-      label: "{{ item.device }}"
+  block:
+      - name: |
+          "1.1.2.2 | PATCH | Ensure nodev option set on /tmp partition | tmp_systemd"
+          "1.1.2.3 | PATCH | Ensure noexec option set on /tmp partition | tmp_systemd"
+          "1.1.2.4 | PATCH | Ensure nosuid option set on /tmp partition | tmp_systemd"
+        ansible.builtin.template:
+            src: etc/systemd/system/tmp.mount.j2
+            dest: /etc/systemd/system/tmp.mount
+            owner: root
+            group: root
+            mode: 0644
+        notify: Remount tmp
+        with_items:
+            - "{{ ansible_mounts }}"
+        loop_control:
+            label: "{{ item.device }}"
+        when:
+            - item.mount == "/tmp"
+            - tmp_mnt_type == 'tmp_systemd'
   when:
-      - item.mount == "/tmp"
-      - tmp_mnt_type == 'tmp_systemd'
-      - ubtu22cis_rule_1_1_2_1 or
-        ubtu22cis_rule_1_1_2_2 or
-        ubtu22cis_rule_1_1_2_3 or
-        ubtu22cis_rule_1_1_2_4
+    - "'/tmp' in mount_names"
+    - ubtu22cis_rule_1_1_2_1 or
+      ubtu22cis_rule_1_1_2_2 or
+      ubtu22cis_rule_1_1_2_3 or
+      ubtu22cis_rule_1_1_2_4
   tags:
-      - level1-server
-      - level1-workstation
-      - automated
-      - patch
-      - rule_1.1.2.2
-      - rule_1.1.2.3
-      - rule_1.1.2.4
-      - tmp
+    - level1-server
+    - level1-workstation
+    - automated
+    - patch
+    - rule_1.1.2.2
+    - rule_1.1.2.3
+    - rule_1.1.2.4
+    - tmp
 
 - name: |
     "1.1.2.2 | PATCH | Ensure nodev option set on /tmp partition | fstab"


### PR DESCRIPTION
**Overall Review of Changes:**
Rename the temporary variable that holds the shell output to prevent the 2nd condition breaking.

**Issue Fixes:**
fix: PRELIM mont type block failing #35

**How has this been tested?:**
Manually tested on a custom Vagrant box with a separate /tmp partition
