### PR TITLE
Blacklist USB-Storage to pass CIS scan

### DIFF
--- a/tasks/section_1/cis_1.1.10.yml
+++ b/tasks/section_1/cis_1.1.10.yml
@@ -9,6 +9,12 @@
             line: 'install usb-storage /bin/true'
             create: true
 
+      - name: "1.1.10 | PATCH | Disable USB Storage | Blacklist usb-storage"
+        ansible.builtin.lineinfile:
+            path: /etc/modprobe.d/blacklist.conf
+            line: 'blacklist usb-storage'
+            insertafter: EOF
+
       - name: "1.1.10 | PATCH | Disable USB Storage | Remove usb-storage module"
         community.general.modprobe:
             name: usb-storage


### PR DESCRIPTION
**Overall Review of Changes:**
Blacklisted usb-storage in /etc/modprobe.d/blacklist.conf 

**Issue Fixes:**
Using the CIS Benchmark we can see that this rule will fail because it was not blacklisted. Now the scan will pass

**Enhancements:**

**How has this been tested?:**
Using ansible 
