### PR TITLE
fix: Fix error in 4.2.1.5 caused by incorrect indent of `notify`

### DIFF
--- a/tasks/section_4/cis_4.2.1.x.yml
+++ b/tasks/section_4/cis_4.2.1.x.yml
@@ -63,7 +63,7 @@
       path: /etc/systemd/journald.conf
       regexp: '^ForwardToSyslog='
       line: '#ForwardToSyslog=yes'
-      notify: Restart journald
+  notify: Restart journald
   when:
       - ubtu22cis_rule_4_2_1_5
   tags:


### PR DESCRIPTION
**Overall Review of Changes:**
Fixes a bug in 4.2.1.5 causing the playbook to fail when using `ubtu22cis_syslog_service == 'journald'`

**Issue Fixes:**
Not reported?

**How has this been tested?:**
Tested on a custom vagrant box
