### PR TITLE
bugfix: When IPv6 is disabled / not available we can not add ufw rule.

### DIFF
--- a/tasks/section_3/cis_3.5.1.x.yml
+++ b/tasks/section_3/cis_3.5.1.x.yml
@@ -85,6 +85,7 @@
             direction: in
             from_ip: '::1'
         notify: Reload ufw
+        when: ubtu22cis_ipv6_required
   when:
       - ubtu22cis_rule_3_5_1_4
   tags:


### PR DESCRIPTION
**Overall Review of Changes:**
Fixes the following exception I have received.
 FAILED! => {"changed": false, "commands": ["/usr/sbin/ufw status verbose", "/usr/bin/grep -h '^### tuple' /lib/ufw/user.rules /lib/ufw/user6.rules /etc/ufw/user.rules /etc/ufw/user6.rules /var/lib/ufw/user.rules /var/lib/ufw/user6.rules", "/usr/sbin/ufw --version", "/usr/sbin/ufw deny in from ::1 to any"], "msg": "ERROR: IPv6 support not enabled\n"
**Issue Fixes:**
Please list (using linking) any open issues this PR addresses

**Enhancements:**
Please list any enhancements/features that are not open issue tickets

**How has this been tested?:**
Running against various hosts.

