### PR TITLE
Modify /etc/aide.conf when ubtu22cis_config_aide is true

### DIFF
--- a/tasks/section_4/cis_4.1.4.x.yml
+++ b/tasks/section_4/cis_4.1.4.x.yml
@@ -197,7 +197,8 @@
       - /sbin/auditd p+i+n+u+g+s+b+acl+xattrs+sha512
       - /sbin/augenrules p+i+n+u+g+s+b+acl+xattrs+sha512
   when:
-      - ubtu22cis_rule_4_1_4_11
+      - ubtu22cis_rule_4_1_4_11 and
+        ubtu22cis_config_aide
   tags:
       - level2-server
       - level2-workstation


### PR DESCRIPTION
**Overall Review of Changes:**
requiring both 'ubtu22cis_rule_4_1_4_11' and 'ubtu22cis_config_aide' to be true to run task '4.1.4.11'

when ubtu22cis_config_aide is `false` there is a chance the aide package is not installed on the system and thus the  `/etc/aide/aide.conf` file will not exist.. this will break the run.

**Issue Fixes:**
N/A

**Enhancements:**
N/A

**How has this been tested?:**
I was able to successfully tested this locally using [molecule](https://ansible.readthedocs.io/projects/molecule/configuration/) and with [Packer](https://www.packer.io/) to build a GCE instance.

The change skipped over the task as intended when 'ubtu22cis_rule_4_1_4_11' was `true` but 'ubtu22cis_config_aide' was `false`.


