### PR TITLE
fix: #68 Role fails when ubtu22cis_time_sync_tool: "systemd-timesyncd…

### DIFF
--- a/tasks/section_2/cis_2.1.3.x.yml
+++ b/tasks/section_2/cis_2.1.3.x.yml
@@ -14,7 +14,6 @@
         ansible.builtin.template:
             src: "{{ item }}.j2"
             dest: "/{{ item }}"
-            state: present
             mode: 0644
             owner: root
             group: root


### PR DESCRIPTION
Role fails when ubtu22cis_time_sync_tool: "systemd-timesyncd" with error "'state' cannot be specified on a template"

**Overall Review of Changes:**
Remove invalid parameter `state` from `ansible.builtin.template`

**Issue Fixes:**
#68 

**Enhancements:**


**How has this been tested?:**
Vagrant Ubuntu 22.04 (bento)

