### PR TITLE
Task validation fixes (by Steampunk Spotter)

### DIFF
--- a/tasks/pre_remediation_audit.yml
+++ b/tasks/pre_remediation_audit.yml
@@ -68,9 +68,8 @@
 
       - name: Pre Audit Setup | If audit ensure goss is available
         ansible.builtin.assert:
+            that: goss_available.stat.exists
             msg: "Audit has been selected: unable to find goss binary at {{ audit_bin }}"
-        when:
-            - not goss_available.stat.exists
   when:
       - run_audit
 

--- a/tasks/section_1/cis_1.8.x.yml
+++ b/tasks/section_1/cis_1.8.x.yml
@@ -72,9 +72,9 @@
             regexp: "{{ item.regexp }}"
             line: "{{ item.line }}"
             insertafter: "{{ item.after | default(omit) }}"
-            loop:
-                - "{ regexp: 'user-db: user', line: 'user' }"
-                - "{ regexp: 'system-db: {{ ubtu22cis_dconf_db_name }}'', after: '^user-db.*' }"
+        loop:
+            - "{ regexp: 'user-db: user', line: 'user' }"
+            - "{ regexp: 'system-db: {{ ubtu22cis_dconf_db_name }}'', after: '^user-db.*' }"
 
       - name: "1.8.4 | PATCH | Ensure GDM screen locks when the user is idle | make directory"
         ansible.builtin.file:


### PR DESCRIPTION
**Overall Review of Changes:**
These changes will try to correct two errors within Ansible tasks that I have come across when running some checks with [Steampunk Spotter](https://steampunk.si/spotter/). 

**Enhancements:**
These changes fix the following two errors detected by the Spotter CLI:

```console
(.venv) user@ubuntu:~/UBUNTU22-CIS$ spotter scan --ansible-version 2.12 --display-level error .
Scanning...success. ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
------------------------------------------------------------------------
tasks/pre_remediation_audit.yml:69:9: ERROR: [E005] that is a required parameter in module ansible.builtin.assert.
tasks/section_1/cis_1.8.x.yml:69:9: ERROR: [E002] loop is not a valid parameter in module ansible.builtin.lineinfile, it looks like a task keyword with incorrect indentation (too many spaces before the keyword).
------------------------------------------------------------------------
Spotter took 2.218 s to scan your input.
It resulted in 2 error(s), 74 warning(s) and 246 hint(s).
Overall status: ERROR
```

**How has this been tested?:**
N/A