### PR TITLE
Removing duplicate variable signifying containerized systems.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,9 +52,6 @@ audit_cmd_timeout: 60000
 # tweak role to run in a chroot, such as in kickstart %post script
 ubtu22cis_system_is_chroot: "{{ ansible_is_chroot | default(False) }}"
 
-# tweak role to run in a non-privileged container
-ubtu22cis_system_is_container: false
-
 # skip events for ec2 instance testing pipeline
 system_is_ec2: false
 

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -80,7 +80,7 @@
   when:
       - ubtu22cis_rule_3_1_2
       - ubtu22cis_install_network_manager
-      - not ubtu22cis_system_is_container
+      - not system_is_container
       - "'network-manager' not in ansible_facts.packages"
   tags:
       - always


### PR DESCRIPTION
**Overall Review of Changes:**
`ubtu22cis_system_is_container`  should be removed and its single occurrence
in a task be replaced by `system_is_container`.

**Issue Fixes:**
Fixes #73 

**Enhancements:**
None

**How has this been tested?:**
n/a.
