### PR TITLE
Adjusting rule-id value in subtasks-name within the task-block for rule 4.2.1.2

### DIFF
--- a/tasks/section_4/cis_4.2.1.x.yml
+++ b/tasks/section_4/cis_4.2.1.x.yml
@@ -8,13 +8,13 @@
         failed_when: false
         register: ubtu22cis_4_2_1_2_status
 
-      - name: "4.2.2.2 | AUDIT | Ensure journald service is enabled | Alert on bad status"
+      - name: "4.2.1.2 | AUDIT | Ensure journald service is enabled | Alert on bad status"
         ansible.builtin.debug:
             msg:
                 - "Warning!! The status of systemd-journald should be static and it is not. Please investigate"
         when: "'static' not in ubtu22cis_4_2_1_2_status.stdout"
 
-      - name: "4.2.2.2 | AUDIT | Ensure journald service is enabled | Warn Count"
+      - name: "4.2.1.2 | AUDIT | Ensure journald service is enabled | Warn Count"
         ansible.builtin.import_tasks: warning_facts.yml
         when: "'static' not in ubtu22cis_4_2_1_2_status.stdout"
   vars:


### PR DESCRIPTION
**Overall Review of Changes:**
Keeping a consistent `(rule_title, rule_var, rule_when) tuple` in the subtasks of rule 4.2.1.2
Did not create an issue for that, but the reasoning behind it is obvious in the below picture:
![4_2_1_2](https://github.com/ansible-lockdown/UBUNTU22-CIS/assets/143085914/f0d1646d-60e7-4d9e-afa8-0e320b90f0da)

**Issue Fixes:**
N/A

**Enhancements:**
N/A

**How has this been tested?:**
N/A

