### PR TITLE
Fixing syntax for 1.8.4, sub-task | session profile |

### DIFF
--- a/tasks/section_1/cis_1.8.x.yml
+++ b/tasks/section_1/cis_1.8.x.yml
@@ -66,8 +66,6 @@
 
 - name: "1.8.4 | PATCH | Ensure GDM screen locks when the user is idle"
   block:
-- name: "1.8.4 | PATCH | Ensure GDM screen locks when the user is idle"
-  block:
       - name: "1.8.4 | PATCH | Ensure GDM screen locks when the user is idle | session profile"
         ansible.builtin.lineinfile:
             path: /etc/dconf/profile/session

--- a/tasks/section_1/cis_1.8.x.yml
+++ b/tasks/section_1/cis_1.8.x.yml
@@ -66,15 +66,18 @@
 
 - name: "1.8.4 | PATCH | Ensure GDM screen locks when the user is idle"
   block:
+- name: "1.8.4 | PATCH | Ensure GDM screen locks when the user is idle"
+  block:
       - name: "1.8.4 | PATCH | Ensure GDM screen locks when the user is idle | session profile"
         ansible.builtin.lineinfile:
             path: /etc/dconf/profile/session
             regexp: "{{ item.regexp }}"
             line: "{{ item.line }}"
             insertafter: "{{ item.after | default(omit) }}"
+            create: yes
         loop:
-            - "{ regexp: 'user-db: user', line: 'user' }"
-            - "{ regexp: 'system-db: {{ ubtu22cis_dconf_db_name }}'', after: '^user-db.*' }"
+          - { regexp: 'user-db:user', line: 'user-db:user' }
+          - { regexp: 'system-db:{{ ubtu22cis_dconf_db_name }}', line: 'system-db:{{ ubtu22cis_dconf_db_name }}', after: '^user-db.*' }
 
       - name: "1.8.4 | PATCH | Ensure GDM screen locks when the user is idle | make directory"
         ansible.builtin.file:

--- a/tasks/section_1/cis_1.8.x.yml
+++ b/tasks/section_1/cis_1.8.x.yml
@@ -74,8 +74,8 @@
             insertafter: "{{ item.after | default(omit) }}"
             create: yes
         loop:
-          - { regexp: 'user-db:user', line: 'user-db:user' }
-          - { regexp: 'system-db:{{ ubtu22cis_dconf_db_name }}', line: 'system-db:{{ ubtu22cis_dconf_db_name }}', after: '^user-db.*' }
+            - { regexp: 'user-db:user', line: 'user-db:user' }
+            - { regexp: 'system-db:{{ ubtu22cis_dconf_db_name }}', line: 'system-db:{{ ubtu22cis_dconf_db_name }}', after: '^user-db.*' }
 
       - name: "1.8.4 | PATCH | Ensure GDM screen locks when the user is idle | make directory"
         ansible.builtin.file:


### PR DESCRIPTION
**Overall Review of Changes:**
Fixing syntax issues identified for `1.8.4, sub-task | session profile`.
**Issue Fixes:**
#91 

**Enhancements:**
N/A

**How has this been tested?:**
Manually, via CIS(`nix_gdm_screen_lock_chk.sh`), as this failure:
```
- Audit Result:
  ** FAIL **
 - Reason(s) for audit failure:

 - The "local" doesn't exist.


- Correctly set:

 - The "idle-delay" option is set to "900" seconds in "/etc/dconf/db/local.d/00-screensaver"
 - The "lock-delay" option is set to "5" seconds in "/etc/dconf/db/local.d/00-screensaver"
 - The "local" profile exists in the dconf database
```
changed to a pass:
```
- Audit Result:
  ** PASS **

 - The "idle-delay" option is set to "900" seconds in "/etc/dconf/db/local.d/00-screensaver"
 - The "lock-delay" option is set to "5" seconds in "/etc/dconf/db/local.d/00-screensaver"
 - The "local" profile exists
 - The "local" profile exists in the dconf database
```

