### PR TITLE
fix(R5.4.3). Correct regexes so that they match

### DIFF
--- a/tasks/section_5/cis_5.4.x.yml
+++ b/tasks/section_5/cis_5.4.x.yml
@@ -113,8 +113,8 @@
       - name: "5.4.3 | PATCH | Ensure password reuse is limited | Set remember value if pam_unix does exist"
         ansible.builtin.lineinfile:
             path: /etc/pam.d/common-password
-            regexp: '^(password\s*\[success=1 default=ignore\] pam_unix.so)(.*)(remember=([0-9]{1,})|)(.*$)'
-            line: '\g<1>\g<2>\g<3> remember={{ ubtu22cis_pamd_pwhistory_remember }}'
+            regexp: '^(?P<begin>[^\S\n]*password[^\S\n]+.*pam_unix.so[^\S\n]+)(?P<remember>(?P<before>.+?)remember=[0-9]+[^\S\n]?)?(?P<after>.*)$'
+            line: '\g<begin>\g<before>remember={{ ubtu22cis_pamd_pwhistory_remember }} \g<after>'
             backrefs: true
         when:
             - ubtu22cis_5_4_3_pam_unix_state.stdout | length > 0
@@ -123,7 +123,7 @@
       - name: "5.4.3 | PATCH | Ensure password reuse is limited | Set remember value if pam_unix does not exist"
         ansible.builtin.lineinfile:
             path: /etc/pam.d/common-password
-            regexp: '^password\s*\[success=1 default=ignore\] pam_unix.*'
+            regexp: '^password.+pam_unix.so.*'
             line: 'password [success=1 default=ignore] pam_unix.so obscure use_authtok try_first_pass remember={{ ubtu22cis_pamd_pwhistory_remember }}'
             insertafter: '^# end of pam-auth-update config'
         when: ubtu22cis_5_4_3_pam_unix_state.stdout | length == 0


### PR DESCRIPTION
**Overall Review of Changes:**
The core is that I improved a regex which do not match:

    '^(password\s*\[success=1 default=ignore\] pam_unix.so)(.*)(remember=([0-9]{1,})|)(.*$)'


to

    '^(?P<begin>[^\S\n]*password[^\S\n]+.*pam_unix.so[^\S\n]+)(?P<remember>(?P<before>.+?)remember=[0-9]+[^\S\n]?)?(?P<after>.*)$'

**Issue Fixes:**
N/A

**Enhancements:**

- The previous regex requires exactly *one* space between
    `default=ignore]` and `pam_unix.so` which on a default OS installation never matches, is now fixed
- The `.*` in `(.*)(remember=([0-9]{1,})|)` of the old regex is greedy, which means that
    everything after it never matches.
- I name the groups now which is easier than the numbers.
- I took care that when inserting a non-existing `remember=`, before and after at least one space is inserted.
- The same time I make sure that *not* on every run, an additional
   space is added on replacement, so that the line is *not* endlessly
   growing.
- The `ansible.builtin.shell: grep 'password.*pam_unix.so' /etc/pam.d/common-password` do not require
    the `[success=1 default=ignore]` but the lineinfile regexes did,
    which would mean that the grep-regex match but not later lineinfile-regexes not ⇒
    I updated it, so that no one requires the `[success=1 default=ignore]`, but
    it will still preserve that part.
- If you wonder about `[^\S\n]`, this is the shortest way to describe what in other regex-languages is known as `\h` (horizontal whitespace). Compared to `\s` this helps especially when there are only empty matches after it.

**How has this been tested?:**

Some manual runs of the changed task which inserted or kept `remember=` option correctly, and

Matching Examples to see regex in action: https://regex101.com/r/Kuxcwj



