### PR TITLE
🐛(R4.1.3.12): Change wrong /var/log/faillog to /var/run/faillock

### DIFF
--- a/templates/audit/99_auditd.rules.j2
+++ b/templates/audit/99_auditd.rules.j2
@@ -68,8 +68,8 @@
 -w /var/log/btmp -p wa -k session
 {% endif %}
 {% if ubtu22cis_rule_4_1_3_12 %}
--w /var/log/faillog -p wa -k logins
 -w /var/log/lastlog -p wa -k logins
+-w /var/run/faillock -p wa -k logins
 {% endif %}
 {% if ubtu22cis_rule_4_1_3_13 %}
 -a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F auid>=1000 -F auid!=4294967295 -k delete


### PR DESCRIPTION
**Overall Review of Changes:**
/var/log/faillog → /var/run/faillock

**Issue Fixes:**
N/A

**Enhancements:**
I think this is a transition error from an old implementation. In [CIS Ubuntu 20.04 v**1**.1](https://workbench.cisecurity.org/sections/752354/recommendations/1229112) it was still /var/log/faillo**g**, but in [CIS Ubuntu 20.04 v**2**.0](https://workbench.cisecurity.org/sections/1985935/recommendations/3181819) it has changed to /var/run/faillo**ck** and hence in CIS Ubuntu 2**2**.04 v1.0 it is also /var/run/faillo**ck**.

**How has this been tested?:**

Executed the task, the `/etc/audit/rules.d/99_auditd.rules` is correctly generated, and `sudo auditctl -l` showed that it was loaded.

