### PR TITLE
fixes a typo in 2.1.1.1

### DIFF
--- a/tasks/section_2/cis_2.1.1.x.yml
+++ b/tasks/section_2/cis_2.1.1.x.yml
@@ -18,7 +18,7 @@
 
       - name: "2.1.1.1 | PATCH | Ensure a single time synchronization daemon is in use | mask service"
         ansible.builtin.service:
-            name: systemd-timesyncd.service
+            name: systemd-timesyncd
             state: stopped
             enabled: false
             masked: true


### PR DESCRIPTION
**Overall Review of Changes:**
typo in rule 2.1.1.1
**Issue Fixes:**
.service on the end causes failure

**Enhancements:**
n/a
**How has this been tested?:**
ran locally
