### PR TITLE
Changing value in defaults/main.yml: Replaced '/etc/default/grub.cfg'…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -573,7 +573,7 @@ ubtu22cis_grub_user_file: /etc/grub.d/00_user
 ubtu22cis_bootloader_password_hash: "grub.pbkdf2.sha512.changethispassword"  # pragma: allowlist secret
 ubtu22cis_set_boot_pass: true
 
-ubtu22cis_grub_file: /etc/default/grub.cfg
+ubtu22cis_grub_file: /boot/grub/grub.cfg
 
 ## Controls 1.6.1.x - apparmor
 # AppArmor security policies define what system resources applications can access and their privileges.


### PR DESCRIPTION
'/etc/default/grub.cfg' REPLACED WITH  '/boot/grub/grub.cfg'

**Overall Review of Changes:**
Changing value in defaults/main.yml: 
``` 
# Replaced '/etc/default/grub.cfg' WITH:
ubtu22cis_grub_file: /boot/grub/grub.cfg
```

**Issue Fixes:**
#115 

**Enhancements:**
N/A

**How has this been tested?:**
Manual CIS assessment
```
36/279: Ensure permissions on bootloader config are configured...................................... Pass
```

