### PR TITLE
🐛 Correct default value for `ubtu22cis_grub_file: /boot/grub/grub.cfg`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -573,7 +573,10 @@ ubtu22cis_grub_user_file: /etc/grub.d/00_user
 ubtu22cis_bootloader_password_hash: "grub.pbkdf2.sha512.changethispassword"  # pragma: allowlist secret
 ubtu22cis_set_boot_pass: true
 
-ubtu22cis_grub_file: /etc/default/grub.cfg
+## Control 1.4.2
+# The grub configuration file contain senitive information, for example boot parameters or passwords.
+# Specify the file here which is used by GRUB during boot.
+ubtu22cis_grub_file: /boot/grub/grub.cfg
 
 ## Controls 1.6.1.x - apparmor
 # AppArmor security policies define what system resources applications can access and their privileges.


### PR DESCRIPTION
**Overall Review of Changes:**

CIS's assessment for rule 1.4.2 Ensure permissions on bootloader config are configured uses wrong `/boot/grub/grub.cfg`. 

**Issue Fixes:**
N/A

**Enhancements:**
I think the current value defined within the variable ubtu22cis_grub_file(respectively /etc/default/grub.cfg) is wrong, as it is a mix between:

DEFAULT FILE: /etc/default/grub
THE AUTO-GENERATED GRUB FILE: /boot/grub/grub.cfg

So the current value `/boot/grub/grub.cfg` is a non-existant file, but CIS rule means `/boot/grub/grub.cfg`.

Thanks to @ipruteanu-sie for finding the issue ;-)

**How has this been tested?:**

Executing the task, look at the result, and  CIS-CAT Scanner succeeds.

