### PR TITLE
Allow multi-line banners

### DIFF
--- a/templates/ansible_vars_goss.yml.j2
+++ b/templates/ansible_vars_goss.yml.j2
@@ -386,7 +386,8 @@ ubtu22cis_apparmor_disable: {{ ubtu22cis_apparmor_disable }}
 ubtu22cis_apparmor_enforce_only: {{ ubtu22cis_apparmor_enforce_only }}
 
 # Warning Banner Content (issue, issue.net, motd)
-ubtu22_warning_banner: {{ ubtu22cis_warning_banner }}
+ubtu22_warning_banner: |
+  {{ ubtu22cis_warning_banner|indent(2, false)  }}
 # End Banner
 
 # Section 2


### PR DESCRIPTION
**Overall Review of Changes:**
Currently a multi-line banner will cause the YAML file to be invalid. This change ensures a valid YAML format without changing behavior.

**Issue Fixes:**
Haven't opened an issue.

**Enhancements:**
Please list any enhancements/features that are not open issue tickets

**How has this been tested?:**
Manually tested with multi-line banner text.

