### PR TITLE
fixes regex catching the trailing quote

### DIFF
--- a/tasks/section_1/cis_1.6.x.yml
+++ b/tasks/section_1/cis_1.6.x.yml
@@ -42,8 +42,8 @@
             regexp: "{{ item.regexp }}"
             replace: "{{ item.replace }}"
         with_items:
-            - { regexp: 'apparmor=\S+', replace: 'apparmor=1' }
-            - { regexp: 'security=\S+', replace: 'security=apparmor' }
+            - { regexp: 'apparmor=\w+', replace: 'apparmor=1' }
+            - { regexp: 'security=\w+', replace: 'security=apparmor' }
         when:
             - "'apparmor' in ubtu22cis_1_6_1_2_cmdline_settings.stdout"
             - "'security' in ubtu22cis_1_6_1_2_cmdline_settings.stdout"


### PR DESCRIPTION
**Overall Review of Changes:**
Change the regex to not match special characters

**Issue Fixes:**
Replaced /S with /w to catch alphanumeric but not quote at EOL

**Enhancements:**
n/a
**How has this been tested?:**
tested locally
