### PR TITLE
Use ansible_facts to reference facts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1048,11 +1048,11 @@ audit_out_dir: '/opt'
 audit_conf_dir: "{{ audit_out_dir }}/{{ benchmark }}-Audit"
 
 # If changed these can affect other products
-pre_audit_outfile: "{{ audit_out_dir }}/{{ ansible_hostname }}-{{ benchmark }}-{{ benchmark_version }}_pre_scan_{{ ansible_date_time.epoch }}.{{ audit_format }}"
-post_audit_outfile: "{{ audit_out_dir }}/{{ ansible_hostname }}-{{ benchmark }}-{{ benchmark_version }}_post_scan_{{ ansible_date_time.epoch }}.{{ audit_format }}"
+pre_audit_outfile: "{{ audit_out_dir }}/{{ ansible_facts.hostname }}-{{ benchmark }}-{{ benchmark_version }}_pre_scan_{{ ansible_facts.date_time.epoch }}.{{ audit_format }}"
+post_audit_outfile: "{{ audit_out_dir }}/{{ ansible_facts.hostname }}-{{ benchmark }}-{{ benchmark_version }}_post_scan_{{ ansible_facts.date_time.epoch }}.{{ audit_format }}"
 
 ## The following should not need changing
-audit_vars_path: "{{ audit_conf_dir }}/vars/{{ ansible_hostname }}.yml"
+audit_vars_path: "{{ audit_conf_dir }}/vars/{{ ansible_facts.hostname }}.yml"
 audit_results: |
       The pre remediation results are: {{ pre_audit_summary }}.
       The post remediation results are: {{ post_audit_summary }}.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -78,14 +78,14 @@
       name: net.ipv4.route.flush
       value: '1'
       sysctl_set: true
-  when: ansible_virtualization_type != "docker"
+  when: ansible_facts.virtualization_type != "docker"
 
 - name: Flush ipv6 route table
   ansible.posix.sysctl:
       name: net.ipv6.route.flush
       value: '1'
       sysctl_set: true
-  when: ansible_virtualization_type != "docker"
+  when: ansible_facts.virtualization_type != "docker"
 
 - name: Reload ufw
   community.general.ufw:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,22 +2,22 @@
 
 - name: Gather distribution info
   # we need:
-  # - hardware for ansible_mounts
+  # - hardware for ansible_facts.mounts
   # - platform for ansible_architecture (ansible internal)
-  # - virtual for ansible_virtualization_type
+  # - virtual for ansible_facts.virtualization_type
   ansible.builtin.setup:
       gather_subset: distribution,hardware,platform,virtual,!all,!min
   when:
-      - ansible_distribution is not defined
+      - ansible_facts.distribution is not defined
   tags:
       - always
 
 - name: Check OS version and family
   ansible.builtin.fail:
-      msg: "This role can only be run against Ubuntu 22. {{ ansible_distribution }} {{ ansible_distribution_major_version }} is not supported."
+      msg: "This role can only be run against Ubuntu 22. {{ ansible_facts.distribution }} {{ ansible_facts.distribution_major_version }} is not supported."
   when:
-      - ansible_distribution == 'Ubuntu'
-      - ansible_distribution_major_version is version_compare('22', '!=')
+      - ansible_facts.distribution == 'Ubuntu'
+      - ansible_facts.distribution_major_version is version_compare('22', '!=')
   tags:
       - always
 
@@ -106,7 +106,7 @@
             - system_is_container
   when:
       - ansible_connection == 'docker' or
-        ansible_virtualization_type in ["docker", "lxc", "openvz", "podman", "container"]
+        ansible_facts.virtualization_type in ["docker", "lxc", "openvz", "podman", "container"]
   tags:
       - container_discovery
       - always

--- a/tasks/pre_remediation_audit.yml
+++ b/tasks/pre_remediation_audit.yml
@@ -20,7 +20,7 @@
         ansible.builtin.package:
             name: git
             state: present
-        when: ansible_distribution_major_version == '8'
+        when: ansible_facts.distribution_major_version == '8'
 
       - name: Pre Audit Setup | Install git (rh7 python2)
         ansible.builtin.package:
@@ -28,7 +28,7 @@
             state: present
         vars:
             ansible_python_interpreter: "{{ python2_bin }}"
-        when: ansible_distribution_major_version == '7'
+        when: ansible_facts.distribution_major_version == '7'
 
       - name: Pre Audit Setup | retrieve audit content files from git
         ansible.builtin.git:

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -24,7 +24,7 @@
 
 - name: "PRELIM | Section 1.1 | Create list of mount points"
   ansible.builtin.set_fact:
-      mount_names: "{{ ansible_mounts | map(attribute='mount') | list }}"
+      mount_names: "{{ ansible_facts.mounts | map(attribute='mount') | list }}"
   tags:
       - always
 

--- a/tasks/section_1/cis_1.1.2.x.yml
+++ b/tasks/section_1/cis_1.1.2.x.yml
@@ -35,7 +35,7 @@
       mode: '0644'
   notify: Remount tmp
   with_items:
-      - "{{ ansible_mounts }}"
+      - "{{ ansible_facts.mounts }}"
   loop_control:
       label: "{{ item.device }}"
   when:
@@ -67,7 +67,7 @@
       opts: defaults,{% if ubtu22cis_rule_1_1_2_2 %}nodev,{% endif %}{% if ubtu22cis_rule_1_1_2_3 %}noexec,{% endif %}{% if ubtu22cis_rule_1_1_2_4 %}nosuid{% endif %}
   notify: remount tmp
   with_items:
-      - "{{ ansible_mounts }}"
+      - "{{ ansible_facts.mounts }}"
   loop_control:
       label: "{{ item.device }}"
   when:

--- a/tasks/section_1/cis_1.1.3.x.yml
+++ b/tasks/section_1/cis_1.1.3.x.yml
@@ -33,7 +33,7 @@
       fstype: "{{ item.fstype }}"
       opts: defaults,{% if ubtu22cis_rule_1_1_3_2 %}nodev,{% endif %}{% if ubtu22cis_rule_1_1_3_3 %}nosuid{% endif %}
   notify: Remount var
-  loop: "{{ ansible_mounts }}"
+  loop: "{{ ansible_facts.mounts }}"
   loop_control:
       label: "{{ item.device }}"
   when:

--- a/tasks/section_1/cis_1.1.4.x.yml
+++ b/tasks/section_1/cis_1.1.4.x.yml
@@ -34,7 +34,7 @@
       fstype: "{{ item.fstype }}"
       opts: defaults,{% if ubtu22cis_rule_1_1_4_2 %}noexec,{% endif %}{% if ubtu22cis_rule_1_1_4_3 %}nosuid,{% endif %}{% if ubtu22cis_rule_1_1_4_4 %}nodev{% endif %}
   notify: Remount var_tmp
-  with_items: "{{ ansible_mounts }}"
+  with_items: "{{ ansible_facts.mounts }}"
   loop_control:
       label: "{{ item.device }}"
   when:

--- a/tasks/section_1/cis_1.1.5.x.yml
+++ b/tasks/section_1/cis_1.1.5.x.yml
@@ -34,7 +34,7 @@
       fstype: "{{ item.fstype }}"
       opts: defaults,{% if ubtu22cis_rule_1_1_5_2 %}nodev,{% endif %}{% if ubtu22cis_rule_1_1_5_3 %}noexec,{% endif %}{% if ubtu22cis_rule_1_1_5_4 %}nosuid{% endif %}
   notify: Remount var_log
-  loop: "{{ ansible_mounts }}"
+  loop: "{{ ansible_facts.mounts }}"
   loop_control:
       label: "{{ item.device }}"
   when:

--- a/tasks/section_1/cis_1.1.6.x.yml
+++ b/tasks/section_1/cis_1.1.6.x.yml
@@ -34,7 +34,7 @@
       fstype: "{{ item.fstype }}"
       opts: defaults,{% if ubtu22cis_rule_1_1_6_2 %}noexec,{% endif %}{% if ubtu22cis_rule_1_1_6_3 %}nodev,{% endif %}{% if ubtu22cis_rule_1_1_6_4 %}nosuid{% endif %}
   notify: Remount var_log_audit
-  loop: "{{ ansible_mounts }}"
+  loop: "{{ ansible_facts.mounts }}"
   loop_control:
       label: "{{ item.device }}"
   when:

--- a/tasks/section_1/cis_1.1.7.x.yml
+++ b/tasks/section_1/cis_1.1.7.x.yml
@@ -33,7 +33,7 @@
       fstype: "{{ item.fstype }}"
       opts: defaults,{% if ubtu22cis_rule_1_1_7_2 %}nodev,{% endif %}{% if ubtu22cis_rule_1_1_7_3 %}nosuid,{% endif %}
   notify: Remount home
-  loop: "{{ ansible_mounts }}"
+  loop: "{{ ansible_facts.mounts }}"
   loop_control:
       label: "{{ item.device }}"
   when:

--- a/tasks/section_6/cis_6.1.x.yml
+++ b/tasks/section_6/cis_6.1.x.yml
@@ -156,7 +156,7 @@
         check_mode: false
         register: ubtu22cis_6_1_10_no_user_items
         with_items:
-            - "{{ ansible_mounts }}"
+            - "{{ ansible_facts.mounts }}"
         loop_control:
             label: "{{ item.mount }}"
 
@@ -211,7 +211,7 @@
         check_mode: false
         register: ubtu22cis_6_1_11_ungrouped_items
         with_items:
-            - "{{ ansible_mounts }}"
+            - "{{ ansible_facts.mounts }}"
         loop_control:
             label: "{{ item.mount }}"
 
@@ -266,7 +266,7 @@
         check_mode: false
         register: ubtu22cis_6_1_12_suid_executables
         with_items:
-            - "{{ ansible_mounts }}"
+            - "{{ ansible_facts.mounts }}"
         loop_control:
             label: "{{ item.mount }}"
 
@@ -321,7 +321,7 @@
         check_mode: false
         register: ubtu22cis_6_1_13_sgid_executables
         with_items:
-            - "{{ ansible_mounts }}"
+            - "{{ ansible_facts.mounts }}"
         loop_control:
             label: "{{ item.mount }}"
 

--- a/tasks/section_6/cis_6.2.x.yml
+++ b/tasks/section_6/cis_6.2.x.yml
@@ -103,12 +103,12 @@
       - name: "6.2.4 | AUDIT | Ensure shadow group is empty | check users in group"
         ansible.builtin.debug:
             msg: "Warning!! - You have users in the shadow group"
-        when: getent_group.shadow[2] | length > 0
+        when: ansible_facts.getent_group.shadow[2] | length > 0
 
       - name: "6.2.4 | AUDIT | Ensure shadow group is empty | check users in group"
         ansible.builtin.import_tasks:
             file: warning_facts.yml
-        when: getent_group.shadow[2] | length > 0
+        when: ansible_facts.getent_group.shadow[2] | length > 0
   vars:
       warn_control_id: '6.2.4'
   when:


### PR DESCRIPTION
**Overall Review of Changes:**

By default, Ansible injects a variable for every fact, prefixed with
ansible_. This can result in a large number of variables for each host,
which at scale can incur a performance penalty. Ansible provides a
configuration option [0] that can be set to False to prevent this
injection of facts. In this case, facts should be referenced via
ansible_facts..

This change updates all references to Ansible facts from using
individual fact variables to using the items in the
ansible_facts dictionary. This allows users to disable fact variable
injection in their Ansible configuration, which may provide some
performance improvement.

[0] https://docs.ansible.com/ansible/latest/reference_appendices/config.html#inject-facts-as-vars

**Issue Fixes:**
No issue, but let me know if you want  me to create one.

**Enhancements:**
- Allows use of inject_facts_as_vars=False. 

**How has this been tested?:**
Ran the role against a host.

