### PR TITLE
adds feature to allow rsync install CIS compliant

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -462,6 +462,7 @@ ubtu22cis_smb_server: false
 ubtu22cis_squid_server: false
 ubtu22cis_snmp_server: false
 ubtu22cis_rsync_server: false
+ubtu22cis_rsync_masked: false
 ubtu22cis_nis_server: false
 ubtu22cis_nfs_client: false
 

--- a/tasks/section_2/cis_2.2.x.yml
+++ b/tasks/section_2/cis_2.2.x.yml
@@ -326,15 +326,29 @@
       - rule_2.2.15
       - postfix
 
-- name: "2.2.16 | PATCH | Ensure rsync service is not installed"
-  ansible.builtin.package:
-      name: rsync
-      state: absent
-  notify: Purge_packages
-  when:
-      - ubtu22cis_rule_2_2_16
-      - not ubtu22cis_rsync_server
-      - "'rsync' in ansible_facts.packages"
+- name: "2.2.16 | PATCH | Ensure rsync service is not installed or masked"
+  block:
+      - name: "2.2.16 | PATCH | Ensure rsync service is disabled and masked"
+        ansible.builtin.service:
+            name: rsync.service
+            state: stopped
+            enabled: false
+            masked: true
+        when:
+            - ubtu22cis_rule_2_2_16
+            - ubtu22cis_rsync_masked
+            - not ubtu22cis_rsync_server
+            - "'rsync' in ansible_facts.packages"
+      - name: "2.2.16 | PATCH | Ensure rsync service is not installed"
+        ansible.builtin.package:
+            name: rsync
+            state: absent
+        notify: Purge_packages
+        when:
+            - ubtu22cis_rule_2_2_16
+            - not ubtu22cis_rsync_masked
+            - not ubtu22cis_rsync_server
+            - "'rsync' in ansible_facts.packages"
   tags:
       - level1-server
       - level1-workstation


### PR DESCRIPTION
**Overall Review of Changes:**
Adds switch to allow rsync to remain installed and CIS compliant. CIS control allows rsync pkg installed with service masked

**Issue Fixes:**

**Enhancements:**
use ubtu22cis_rsync_masked: true to leave rsync installed and mask/disable the service

**How has this been tested?:**
tested locally
