### PR TITLE
Siemens/feat/rule 1.6.1.3 enforce vs complain

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -586,15 +586,16 @@ ubtu22cis_grub_file: /boot/grub/grub.cfg
 # This automatically limits the damage that the software can do to files accessible by the calling user.
 # The following variables are related to the set of rules from section 1.6.1.x
 
-# This variable disables the rule regarding enforcing profiles or putting them in complain mode
+## Controls 1.6.1.3 and 1.6.1.4 Ensure all AppArmor Profiles are in enforce (1.6.1.3/4) or complain (1.6.1.3) mode
+
+# This variable disables the implementation of rules 1.6.1.3 and 1.6.1.4
+# regarding enforcing profiles or putting them in complain mode
 ubtu22cis_apparmor_disable: false
-# This variable specifies whether enforce mode or complain  mode is set in control 1.6.1.3.
+
+# This variable specifies whether enforce mode or complain  mode is set in Control 1.6.1.3.
 # Possible values are `enforce` and `complain`.
-# Note that this control and control 1.6.1.4 influence the same setting, but Control 1.6.1.4
-# is part of the Level 2 profile, whereas Control 1.6.1.3 is part of the Level 1 profile
-# If Control 1.6.1.4 is run (which sets all profiles to enforce mode), then Control 1.6.1.3
-# is skipped!
-# Note also that if you set this variable to `enforce`, then Control 1.6.1.3 and 1.6.1.4 are identical.
+# ATTENTION: if Control 1.6.1.4 is run (e.g., when running level 2 rules), it OVERRIDES control 1.6.1.3
+# and sets `enforce` mode, no matter what this variable's value is.
 ubtu22cis_apparmor_mode: complain
 
 ## Controls 1.7.x  - Warning banners

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -590,7 +590,12 @@ ubtu22cis_grub_file: /boot/grub/grub.cfg
 ubtu22cis_apparmor_disable: false
 # This variable specifies whether enforce mode or complain  mode is set in control 1.6.1.3.
 # Possible values are `enforce` and `complain`.
-ubtu22cis_apparmor_mode: enforce
+# Note that this control and control 1.6.1.4 influence the same setting, but Control 1.6.1.4
+# is part of the Level 2 profile, whereas Control 1.6.1.3 is part of the Level 1 profile
+# If Control 1.6.1.4 is run (which sets all profiles to enforce mode), then Control 1.6.1.3
+# is skipped!
+# Note also that if you set this variable to `enforce`, then Control 1.6.1.3 and 1.6.1.4 are identical.
+ubtu22cis_apparmor_mode: complain
 
 ## Controls 1.7.x  - Warning banners
 # The controls 1.7.x set various warning banners and protect the respective files

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -588,12 +588,9 @@ ubtu22cis_grub_file: /boot/grub/grub.cfg
 
 # This variable disables the rule regarding enforcing profiles or putting them in complain mode
 ubtu22cis_apparmor_disable: false
-# This variable chooses how the profiles will comply to rule 1.6.1.3.
-# If it is set to true the profiles will be in enforce mode
-# If it is set to false the profiles will be in complain mode
-# *? The role has two tasks that do the same thing no matter what boolean
-# value is set to this variable *?
-ubtu22cis_apparmor_enforce_only: false
+# This variable specifies whether enforce mode or complain  mode is set in control 1.6.1.3.
+# Possible values are `enforce` and `complain`.
+ubtu22cis_apparmor_mode: enforce
 
 ## Controls 1.7.x  - Warning banners
 # The controls 1.7.x set various warning banners and protect the respective files

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -1,4 +1,7 @@
 ---
+- name: "PRELIM | Set default values for facts"
+  ansible.builtin.set_fact:
+    control_1_6_1_4_was_run: false
 
 - name: "PRELIM | Register if snap being used"
   ansible.builtin.shell: df -h | grep -wc "/snap"

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -2,6 +2,9 @@
 - name: "PRELIM | Set default values for facts"
   ansible.builtin.set_fact:
     control_1_6_1_4_was_run: false
+    ubtu22cis_apparmor_enforce_only: false
+  changed_when: false
+
 
 - name: "PRELIM | Register if snap being used"
   ansible.builtin.shell: df -h | grep -wc "/snap"

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -1,10 +1,9 @@
 ---
 - name: "PRELIM | Set default values for facts"
   ansible.builtin.set_fact:
-    control_1_6_1_4_was_run: false
-    ubtu22cis_apparmor_enforce_only: false
+      control_1_6_1_4_was_run: false
+      ubtu22cis_apparmor_enforce_only: false
   changed_when: false
-
 
 - name: "PRELIM | Register if snap being used"
   ansible.builtin.shell: df -h | grep -wc "/snap"

--- a/tasks/section_1/cis_1.6.x.yml
+++ b/tasks/section_1/cis_1.6.x.yml
@@ -85,6 +85,8 @@
       - name: "1.6.1.4 | PATCH | Ensure all AppArmor Profiles are enforcing | Make sure that 1.6.1.3 is not run"
         ansible.builtin.set_fact:
           control_1_6_1_4_was_run: true
+          ubtu22cis_apparmor_enforce_only: true
+        changed_when: false
 
       - name: "1.6.1.4 | PATCH | Ensure all AppArmor Profiles are enforcing | Get pre apply enforce count"
         ansible.builtin.shell: apparmor_status |  grep "profiles are in enforce mode" | tr -d -c 0-9
@@ -122,6 +124,18 @@
 
 - name: "1.6.1.3 | PATCH | Ensure all AppArmor Profiles are in enforce or complain mode"
   block:
+      - name: "1.6.1.3 | AUDIT | Ensure all AppArmor Profiles are in enforce or complain | Set ubtu22cis_apparmor_enforce_only true for GOSS"
+        ansible.builtin.set_fact:
+          ubtu22cis_apparmor_enforce_only: true
+        changed_when: false
+        when:
+          - ubtu22cis_apparmor_mode == "enforce"
+      - name: "1.6.1.3 | AUDIT | Ensure all AppArmor Profiles are in enforce or complain | Set ubtu22cis_apparmor_enforce_only false for GOSS"
+        ansible.builtin.set_fact:
+          ubtu22cis_apparmor_enforce_only: false
+        changed_when: false
+        when:
+          - ubtu22cis_apparmor_mode == "complain"
       - name: "1.6.1.3 | PATCH | Ensure all AppArmor Profiles are in enforce or complain mode | Get pre apply enforce count"
         ansible.builtin.shell: apparmor_status |  grep "profiles are in {{ubtu22cis_apparmor_mode}} mode" | tr -d -c 0-9
         changed_when: false

--- a/tasks/section_1/cis_1.6.x.yml
+++ b/tasks/section_1/cis_1.6.x.yml
@@ -80,31 +80,30 @@
 - name: "1.6.1.3 | PATCH | Ensure all AppArmor Profiles are in enforce or complain mode"
   block:
       - name: "1.6.1.3 | PATCH | Ensure all AppArmor Profiles are in enforce or complain mode | Get pre apply enforce count"
-        ansible.builtin.shell: apparmor_status |  grep "profiles are in enforce mode" | tr -d -c 0-9
+        ansible.builtin.shell: apparmor_status |  grep "profiles are in {{ubtu22cis_apparmor_mode}} mode" | tr -d -c 0-9
         changed_when: false
         failed_when: false
         register: ubtu22cis_1_6_1_3_pre_count
 
-      - name: "1.6.1.3 | PATCH | Ensure all AppArmor Profiles are in enforce or complain mode | Apply enforcing to /etc/apparmor.d profiles"
-        ansible.builtin.shell: aa-enforce /etc/apparmor.d/*
+      - name: "1.6.1.3 | PATCH | Ensure all AppArmor Profiles are in enforce or complain mode | Apply complaining/enforcing to /etc/apparmor.d profiles"
+        ansible.builtin.shell: aa-{{ubtu22cis_apparmor_mode}} /etc/apparmor.d/*
         changed_when: false
         failed_when: false
 
       - name: "1.6.1.3 | PATCH | Ensure all AppArmor Profiles are in enforce or complain mode | Get post apply enforce count"
-        ansible.builtin.shell: apparmor_status |  grep "profiles are in enforce mode" | tr -d -c 0-9
+        ansible.builtin.shell: apparmor_status |  grep "profiles are in {{ubtu22cis_apparmor_mode}} mode" | tr -d -c 0-9
         changed_when: false
         failed_when: false
         register: ubtu22cis_1_6_1_3_post_count
 
       - name: "1.6.1.3 | PATCH | Ensure all AppArmor Profiles are in enforce or complain mode | This flags for idempotency"
         ansible.builtin.debug:
-            msg: Changed! The profiles in /etc/apparmor.d were set to enforcing
+            msg: Changed! The profiles in /etc/apparmor.d were set to {{ubtu22cis_apparmor_mode}} mode
         changed_when: true
         when: ubtu22cis_1_6_1_3_pre_count.stdout != ubtu22cis_1_6_1_3_post_count.stdout
   when:
       - ubtu22cis_rule_1_6_1_3
       - not ubtu22cis_apparmor_disable
-      - not ubtu22cis_apparmor_enforce_only
   tags:
       - level1-server
       - level1-workstation

--- a/tasks/section_1/cis_1.6.x.yml
+++ b/tasks/section_1/cis_1.6.x.yml
@@ -76,7 +76,50 @@
       - rule_1.6.1.2
       - apparmor
 
-# This is handled via this block to allow for proper flagging of idempotency for the control
+# Controls 1.6.1.4 and 1.6.1.3 target the same setting and thus should not be run together.
+# Because control 1.6.1.4 is stricter than 1.6.1.3, we need to change the order --
+# control 1.6.1.4 then registers the fact that is has run and thus keeps 1.6.1.3 from running.
+
+- name: "1.6.1.4 | PATCH | Ensure all AppArmor Profiles are enforcing"
+  block:
+      - name: "1.6.1.4 | PATCH | Ensure all AppArmor Profiles are enforcing | Make sure that 1.6.1.3 is not run"
+        ansible.builtin.set_fact:
+          control_1_6_1_4_was_run: true
+
+      - name: "1.6.1.4 | PATCH | Ensure all AppArmor Profiles are enforcing | Get pre apply enforce count"
+        ansible.builtin.shell: apparmor_status |  grep "profiles are in enforce mode" | tr -d -c 0-9
+        changed_when: false
+        failed_when: false
+        register: ubtu22cis_1_6_1_4_pre_count
+
+      - name: "1.6.1.4 | PATCH | Ensure all AppArmor Profiles are enforcing | Apply enforcing to /etc/apparmor.d profiles"
+        ansible.builtin.shell: aa-enforce /etc/apparmor.d/*
+        changed_when: false
+        failed_when: false
+
+      - name: "1.6.1.4 | PATCH | Ensure all AppArmor Profiles are enforcing | Get post apply enforce count"
+        ansible.builtin.shell: apparmor_status |  grep "profiles are in enforce mode" | tr -d -c 0-9
+        changed_when: false
+        failed_when: false
+        register: ubtu22cis_1_6_1_4_post_count
+
+      - name: "1.6.1.4 | PATCH | Ensure all AppArmor Profiles are enforcing | This flags for idempotency"
+        ansible.builtin.debug:
+            msg: Changed! The profiles in /etc/apparmor.d were set to enforcing
+        changed_when: true
+        when: ubtu22cis_1_6_1_4_pre_count.stdout != ubtu22cis_1_6_1_4_post_count.stdout
+  when:
+      - ubtu22cis_rule_1_6_1_4
+      - not ubtu22cis_apparmor_disable
+  tags:
+      - level2-server
+      - level2-workstation
+      - automated
+      - scored
+      - patch
+      - rule_1.6.1.4
+      - apparmor
+
 - name: "1.6.1.3 | PATCH | Ensure all AppArmor Profiles are in enforce or complain mode"
   block:
       - name: "1.6.1.3 | PATCH | Ensure all AppArmor Profiles are in enforce or complain mode | Get pre apply enforce count"
@@ -104,6 +147,7 @@
   when:
       - ubtu22cis_rule_1_6_1_3
       - not ubtu22cis_apparmor_disable
+      - not control_1_6_1_4_was_run
   tags:
       - level1-server
       - level1-workstation
@@ -112,39 +156,3 @@
       - rule_1.6.1.3
       - apparmor
 
-- name: "1.6.1.4 | PATCH | Ensure all AppArmor Profiles are enforcing"
-  block:
-      - name: "1.6.1.4 | PATCH | Ensure all AppArmor Profiles are enforcing | Get pre apply enforce count"
-        ansible.builtin.shell: apparmor_status |  grep "profiles are in enforce mode" | tr -d -c 0-9
-        changed_when: false
-        failed_when: false
-        register: ubtu22cis_1_6_1_4_pre_count
-
-      - name: "1.6.1.4 | PATCH | Ensure all AppArmor Profiles are enforcing | Apply enforcing to /etc/apparmor.d profiles"
-        ansible.builtin.shell: aa-enforce /etc/apparmor.d/*
-        changed_when: false
-        failed_when: false
-
-      - name: "1.6.1.4 | PATCH | Ensure all AppArmor Profiles are enforcing | Get post apply enforce count"
-        ansible.builtin.shell: apparmor_status |  grep "profiles are in enforce mode" | tr -d -c 0-9
-        changed_when: false
-        failed_when: false
-        register: ubtu22cis_1_6_1_4_post_count
-
-      - name: "1.6.1.4 | PATCH | Ensure all AppArmor Profiles are enforcing | This flags for idempotency"
-        ansible.builtin.debug:
-            msg: Changed! The profiles in /etc/apparmor.d were set to enforcing
-        changed_when: true
-        when: ubtu22cis_1_6_1_4_pre_count.stdout != ubtu22cis_1_6_1_4_post_count.stdout
-  when:
-      - ubtu22cis_rule_1_6_1_4
-      - not ubtu22cis_apparmor_disable
-      - ubtu22cis_apparmor_enforce_only
-  tags:
-      - level2-server
-      - level2-workstation
-      - automated
-      - scored
-      - patch
-      - rule_1.6.1.4
-      - apparmor

--- a/tasks/section_1/cis_1.6.x.yml
+++ b/tasks/section_1/cis_1.6.x.yml
@@ -84,8 +84,8 @@
   block:
       - name: "1.6.1.4 | PATCH | Ensure all AppArmor Profiles are enforcing | Make sure that 1.6.1.3 is not run"
         ansible.builtin.set_fact:
-          control_1_6_1_4_was_run: true
-          ubtu22cis_apparmor_enforce_only: true
+            control_1_6_1_4_was_run: true
+            ubtu22cis_apparmor_enforce_only: true
         changed_when: false
 
       - name: "1.6.1.4 | PATCH | Ensure all AppArmor Profiles are enforcing | Get pre apply enforce count"
@@ -126,16 +126,16 @@
   block:
       - name: "1.6.1.3 | AUDIT | Ensure all AppArmor Profiles are in enforce or complain | Set ubtu22cis_apparmor_enforce_only true for GOSS"
         ansible.builtin.set_fact:
-          ubtu22cis_apparmor_enforce_only: true
+            ubtu22cis_apparmor_enforce_only: true
         changed_when: false
         when:
-          - ubtu22cis_apparmor_mode == "enforce"
+            - ubtu22cis_apparmor_mode == "enforce"
       - name: "1.6.1.3 | AUDIT | Ensure all AppArmor Profiles are in enforce or complain | Set ubtu22cis_apparmor_enforce_only false for GOSS"
         ansible.builtin.set_fact:
-          ubtu22cis_apparmor_enforce_only: false
+            ubtu22cis_apparmor_enforce_only: false
         changed_when: false
         when:
-          - ubtu22cis_apparmor_mode == "complain"
+            - ubtu22cis_apparmor_mode == "complain"
       - name: "1.6.1.3 | PATCH | Ensure all AppArmor Profiles are in enforce or complain mode | Get pre apply enforce count"
         ansible.builtin.shell: apparmor_status |  grep "profiles are in {{ubtu22cis_apparmor_mode}} mode" | tr -d -c 0-9
         changed_when: false

--- a/tasks/section_1/cis_1.6.x.yml
+++ b/tasks/section_1/cis_1.6.x.yml
@@ -169,4 +169,3 @@
       - patch
       - rule_1.6.1.3
       - apparmor
-

--- a/templates/ansible_vars_goss.yml.j2
+++ b/templates/ansible_vars_goss.yml.j2
@@ -383,7 +383,7 @@ ubtu22cis_bootloader_password: {{ ubtu22cis_bootloader_password_hash }}
 
 # 1.6 - Only have apparmor enforcing
 ubtu22cis_apparmor_disable: {{ ubtu22cis_apparmor_disable }}
-ubtu22cis_apparmor_enforce_only: {{ ubtu22cis_apparmor_enforce_only }}
+ubtu22cis_apparmor_mode: {{ ubtu22cis_apparmor_mode }}
 
 # Warning Banner Content (issue, issue.net, motd)
 ubtu22_warning_banner: {{ ubtu22cis_warning_banner }}

--- a/templates/ansible_vars_goss.yml.j2
+++ b/templates/ansible_vars_goss.yml.j2
@@ -384,6 +384,7 @@ ubtu22cis_bootloader_password: {{ ubtu22cis_bootloader_password_hash }}
 # 1.6 - Only have apparmor enforcing
 ubtu22cis_apparmor_disable: {{ ubtu22cis_apparmor_disable }}
 ubtu22cis_apparmor_mode: {{ ubtu22cis_apparmor_mode }}
+ubtu22cis_apparmor_enforce_only: {{ubtu22cis_apparmor_enforce_only}}
 
 # Warning Banner Content (issue, issue.net, motd)
 ubtu22_warning_banner: {{ ubtu22cis_warning_banner }}


### PR DESCRIPTION
**Overall Review of Changes:**

Control 1.6.1.3 mandates to `Ensure all AppArmor Profiles are in enforce or complain mode`.
However, the corresponding task only allows the role to set every profile to `enforce` mode --
the existing toggle in `defaults/main.yml` disables the tasks rather than switching between
`enforce` and `complain`  mode.

**Issue Fixes:**
#93 

**Enhancements:**
n/a
**How has this been tested?:**
Tested locally.
