### PR TITLE
if timesyncd is not installed 2.1.1.1 errors

### DIFF
--- a/tasks/section_2/cis_2.1.1.x.yml
+++ b/tasks/section_2/cis_2.1.1.x.yml
@@ -23,7 +23,10 @@
             enabled: false
             masked: true
             daemon_reload: true
-        when: ubtu22cis_time_sync_tool != "systemd-timesyncd"
+        when:
+            - ubtu22cis_time_sync_tool != "systemd-timesyncd"
+            - "'systemd-timesyncd' in ansible_facts.packages"
+
   when:
       - ubtu22cis_rule_2_1_1_1
   tags:


### PR DESCRIPTION
**Overall Review of Changes:**
Make sure timesyncd is installed before manipulating the service

**Issue Fixes:**
Fixes error when timesyncd is not installed

**Enhancements:**
n/a

**How has this been tested?:**
tested locally
