### PR TITLE
fix: #161 NTP should be a space-separated list of NTP server host nam…

### DIFF
--- a/templates/etc/systemd/timesyncd.conf.d/50-timesyncd.conf.j2
+++ b/templates/etc/systemd/timesyncd.conf.d/50-timesyncd.conf.j2
@@ -2,7 +2,8 @@
 # Added as part of ansible-lockdown CIS baseline
 # provided by MindPointGroup LLC
 
-NTP={{ ubtu22cis_time_pool }}
+[Time]
+NTP={% for pool in ubtu22cis_time_pool %}{{ pool.name }} {% endfor %}
 
 
 FallbackNTP={% for servers in ubtu22cis_time_servers %}{{ servers.name }} {% endfor %}


### PR DESCRIPTION
**Overall Review of Changes:**
NTP should be a space-separated list of NTP server host names or IP addresses, instead of a JSON encoded list of objects. 

Also added the section label [Time] to fix the log message `/etc/systemd/timesyncd.conf.d/50-timesyncd.conf:8: Assignment outside of section. Ignoring.`

**Issue Fixes:**
#161 

**Enhancements:**


**How has this been tested?:**
This was tested on a physical machine with Ubuntu server minimal 22.04, with the time_pool value from `/defaults`. 

