### PR TITLE
fix: timesyncd.conf missing [Time] section

### DIFF
--- a/templates/etc/systemd/timesyncd.conf.d/50-timesyncd.conf.j2
+++ b/templates/etc/systemd/timesyncd.conf.d/50-timesyncd.conf.j2
@@ -3,7 +3,7 @@
 # provided by MindPointGroup LLC
 
 [Time]
-NTP={{ ubtu22cis_time_pool }}
+NTP={% for servers in ubtu22cis_time_pool %}{{ servers.name }} {% endfor %}
 
 
 FallbackNTP={% for servers in ubtu22cis_time_servers %}{{ servers.name }} {% endfor %}

--- a/templates/etc/systemd/timesyncd.conf.d/50-timesyncd.conf.j2
+++ b/templates/etc/systemd/timesyncd.conf.d/50-timesyncd.conf.j2
@@ -2,6 +2,7 @@
 # Added as part of ansible-lockdown CIS baseline
 # provided by MindPointGroup LLC
 
+[Time]
 NTP={{ ubtu22cis_time_pool }}
 
 


### PR DESCRIPTION
**Overall Review of Changes:**
Adding the `[Time]` header to the timesyncd.conf template to allow for the configuration file to be properly parsed by timesyncd daemon.

**Issue Fixes:**
n/a

**Enhancements:**
n/a

**How has this been tested?:**
I tested this locally during a packer build and observed the following via journalctl
```
$ journalctl -u systemd-timesyncd.service
...
Nov 08 22:28:13 packer-654c02ef-a137-f71d-a70b-47036632b345 systemd[1]: Starting Network Time Synchronization...
Nov 08 22:28:13 packer-654c02ef-a137-f71d-a70b-47036632b345 systemd-timesyncd[286]: /etc/systemd/timesyncd.conf.d/50-timesyncd.conf:5: Assignment outside of section. Ignoring.
Nov 08 22:28:13 packer-654c02ef-a137-f71d-a70b-47036632b345 systemd-timesyncd[286]: /etc/systemd/timesyncd.conf.d/50-timesyncd.conf:8: Assignment outside of section. Ignoring.

# modifying file locally
$ cat /etc/systemd/timesyncd.conf.d/50-timesyncd.conf
## Ansible controlled file
# Added as part of ansible-lockdown CIS baseline
# provided by MindPointGroup LLC

[Time]
NTP=time.nist.gov


FallbackNTP=time-a-g.nist.gov time-b-g.nist.gov time-c-g.nist.gov

# restart systemd-timesyncd service
$ systemctl restart systemd-timesyncd.service

# validating configuration is properly reflected
$ journalctl -u systemd-timesyncd.service
Nov 08 22:34:07 packer-654c02ef-a137-f71d-a70b-47036632b345 systemd[1]: Started Network Time Synchronization.
Nov 08 22:34:07 packer-654c02ef-a137-f71d-a70b-47036632b345 systemd-timesyncd[1133]: Initial synchronization to time server 132.163.97.3:123 (time.nist.gov).
```

By default the [ubtu22cis_time_pool](https://github.com/ansible-lockdown/UBUNTU22-CIS/blob/devel/defaults/main.yml#L655-L657) appears to template out as the following. systemd-timesyncd does not parse this well.

```
NTP=[{'name': 'time.nist.gov', 'options': 'iburst maxsources 4'}]
```

I've copied the logic from `FallbackNTP` to also iterate and render NTP servers in the same manner for the NTP directive.

