### PR TITLE
fix: #172 checks if ipv6.disable is present in GRUB_CMDLINE_LINUX bef…

### DIFF
--- a/tasks/section_3/cis_3.1.x.yml
+++ b/tasks/section_3/cis_3.1.x.yml
@@ -11,13 +11,23 @@
         register: ipv6disable_replaced
         notify: Grub update
 
+      - name: "3.1.1 | PATCH | Ensure system is checked to determine if IPv6 is enabled | Check grub cmdline linux"
+        ansible.builtin.shell: 'cat /etc/default/grub | grep ^GRUB_CMDLINE_LINUX'
+        changed_when: false
+        failed_when: false
+        check_mode: false
+        register: ubtu22cis_3_1_1_GRUB_CMDLINE_LINUX
+        when: ubtu22cis_ipv6_disable == 'grub'
+
       - name: "3.1.1 | PATCH | Ensure system is checked to determine if IPv6 is enabled | Insert ipv6.disable if it doesn't exist"
         ansible.builtin.lineinfile:
             path: /etc/default/grub
             regexp: '^(GRUB_CMDLINE_LINUX=".*)"$'
             line: '\1 ipv6.disable=1"'
             backrefs: true
-        when: ipv6disable_replaced is not changed
+        when:
+         - ipv6disable_replaced is not changed
+         - "'ipv6.disable' not in ubtu22cis_3_1_1_GRUB_CMDLINE_LINUX.stdout"
         notify: Grub update
 
       - name: "3.1.1 | PATCH | Ensure system is checked to determine if IPv6 is enabled | Remove net.ipv6.conf.all.disable_ipv6"

--- a/tasks/section_3/cis_3.1.x.yml
+++ b/tasks/section_3/cis_3.1.x.yml
@@ -12,11 +12,11 @@
         notify: Grub update
 
       - name: "3.1.1 | PATCH | Ensure system is checked to determine if IPv6 is enabled | Check grub cmdline linux"
-        ansible.builtin.shell: 'cat /etc/default/grub | grep ^GRUB_CMDLINE_LINUX'
+        ansible.builtin.shell: grep "GRUB_CMDLINE_LINUX=" /etc/default/grub | cut -f2 -d'"'
         changed_when: false
         failed_when: false
         check_mode: false
-        register: ubtu22cis_3_1_1_GRUB_CMDLINE_LINUX
+        register: ubtu22cis_3_1_1_cmdline_settings
         when: ubtu22cis_ipv6_disable == 'grub'
 
       - name: "3.1.1 | PATCH | Ensure system is checked to determine if IPv6 is enabled | Insert ipv6.disable if it doesn't exist"
@@ -26,8 +26,8 @@
             line: '\1 ipv6.disable=1"'
             backrefs: true
         when:
-         - ipv6disable_replaced is not changed
-         - "'ipv6.disable' not in ubtu22cis_3_1_1_GRUB_CMDLINE_LINUX.stdout"
+            - ipv6disable_replaced is not changed
+            - "'ipv6.disable' not in ubtu22cis_3_1_1_cmdline_settings.stdout"
         notify: Grub update
 
       - name: "3.1.1 | PATCH | Ensure system is checked to determine if IPv6 is enabled | Remove net.ipv6.conf.all.disable_ipv6"


### PR DESCRIPTION
Checks if ipv6.disable is present in GRUB_CMDLINE_LINUX before appending it to prevent duplication

**Overall Review of Changes:**
Adds a task to get the current value before appending
Adds a second condition to only append it wasn't changed by the previous task and doesn't already exist in the file

**Issue Fixes:**
172

**Enhancements:**
none

**How has this been tested?:**
A physical server, running Ubuntu 22.04 minimal installation, was already provisioned then ran the playbook multiple times. 

With existing different value
![image](https://github.com/ansible-lockdown/UBUNTU22-CIS/assets/1018251/846b4967-33e0-4880-bf29-b7324c663931)

With no existing value
![image](https://github.com/ansible-lockdown/UBUNTU22-CIS/assets/1018251/234e2822-3b1f-4500-baa8-a4edb4a17a0a)

When the current value matches the expected value
![image](https://github.com/ansible-lockdown/UBUNTU22-CIS/assets/1018251/80f0ad40-e29b-434e-99eb-c13f911f48cd)


