### PR TITLE
Audit standalone

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,13 @@
 
 ## Based on CIS V1.0.0
 
+### 1.0.8
+
+- updated goss binary to 0.4.4
+- moved majority of audit variables to vars/audit.yml
+- new function to enable audit_only using remediation
+- removed some dupes in audit config
+
 ### 1.0.7
 
 Huge thanks to the discord community

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,48 +52,42 @@ ubtu22cis_uses_root: false
 ### Settings for associated Audit role using Goss
 ###
 
-# Note that there are also variable regarding the retrieval
-# and configuration of Goss and the audit role at the end
-# of this file.
+##########################################
+### Goss is required on the remote host ###
+## Refer to vars/auditd.yml for any other settings ##
 
-## Audit setup
-# Audits are carried out using Goss. This variable
-# determines whether execution of the role prepares for auditing
-# by installing the required binary.
+# Allow audit to setup the requirements including installing git (if option chosen and downloading and adding goss binary to system)
 setup_audit: false
-## How to retrieve audit binary
-# Options are copy or download, using either the path
-# provided in variable `audit_conf_copy` for copying or
-# the url given in variable `audit_files_url` for downloading.
-get_audit_binary_method: download
 
-## How to retrieve the audit role
-# The role for auditing is maintained separately.
-# This variable specifies the method of how to get the audit role
-# onto the system. The options are as follows:
-# - git: clone from git repository as specified in variable `audit_file_git` in
-#   the version specified by variable `audit_git_version`
-# - copy: copy from path as specified in variable `audit_conf_copy`
-# - download: Download from url as specified in variable `audit_files_url`
-audit_content: git
-
-## Enable audits to run
-# This variable governs whether the audit using the
-# separately maintained audit role using Goss
-# is carried out.
+# enable audits to run - this runs the audit and get the latest content
 run_audit: false
 
-## Resource-intensive Tests
-# This variable governs whether resource-intensive audit tests are carried out
+# Only run Audit do not remediate
+audit_only: false
+# As part of audit_only
+# This will enable files to be copied back to control node
+capture_audit_files: false
+# Path to copy the files to will create dir structure
+audit_capture_files_dir: /some/location to copy to on control node
+
+# How to retrieve audit binary
+# Options are copy or download - detailed settings at the bottom of this file
+# you will need to access to either github or the file already dowmloaded
+get_audit_binary_method: download
+
+# how to get audit files onto host options
+# options are git/copy/get_url other e.g. if you wish to run from already downloaded conf
+audit_content: git
+
+# Run heavy tests - some tests can have more impact on a system enabling these can have greater impact on a system
 audit_run_heavy_tests: true
+
 # This variable specifies the timeout (in ms) for audit commands that
 # take a very long time: if a command takes too long to complete,
 # it will be forcefully terminated after the specified duration.
-audit_cmd_timeout: 60000
+audit_cmd_timeout: 120000
 
-###
-### End Audit Settings for associcated Audit role using Goss
-###
+### End Goss enablements ####
 
 ## Running role under chroot
 # Tweak role to run in a chroot, such as in a kickstart %post script.
@@ -1058,56 +1052,3 @@ ubtu22cis_sgid_adjust: false
 # permissions on dot files.
 # Possible values are `true` and `false`.
 ubtu22cis_dotperm_ansiblemanaged: true
-
-##
-## Audit Configuration Settings
-##
-
-# The settings below configure the retrieval and usage of the
-# Goss-based audit role associated with this role, and the Goss-tool
-# itself.
-
-## Audit binary settings
-audit_bin_version:
-    release: v0.4.0
-    checksum: 'sha256:9cb37863d3d25e2af80cb5cf55198c0c115b2477724153ba9afd0a2e544cb46e'
-audit_bin_path: /usr/local/bin/
-audit_bin: "{{ audit_bin_path }}goss"
-audit_format: json
-
-# if get_audit_binary_method == download change accordingly
-audit_bin_url: "https://github.com/goss-org/goss/releases/download/{{ audit_bin_version.release }}/goss-linux-amd64"
-
-# if get_audit_binary_method - copy the following needs to be updated for your environment
-# it is expected that it will be copied from somewhere accessible to the control node
-# e.g copy from ansible control node to remote host
-audit_bin_copy_location: /some/accessible/path
-
-## Goss Audit Benchmark file
-# managed by the control audit_content
-# git
-audit_file_git: "https://github.com/ansible-lockdown/{{ benchmark }}-Audit.git"
-audit_git_version: "benchmark-{{ benchmark_version }}"
-
-# archive or copy:
-audit_conf_copy: "some path to copy from"
-
-# get_url:
-audit_files_url: "some url maybe s3?"
-
-## Goss configuration information
-# Where the goss configs and outputs are stored
-audit_out_dir: '/opt'
-# Where the goss audit configuration will be stored
-audit_conf_dir: "{{ audit_out_dir }}/{{ benchmark }}-Audit"
-
-# If changed these can affect other products
-pre_audit_outfile: "{{ audit_out_dir }}/{{ ansible_facts.hostname }}-{{ benchmark }}-{{ benchmark_version }}_pre_scan_{{ ansible_facts.date_time.epoch }}.{{ audit_format }}"
-post_audit_outfile: "{{ audit_out_dir }}/{{ ansible_facts.hostname }}-{{ benchmark }}-{{ benchmark_version }}_post_scan_{{ ansible_facts.date_time.epoch }}.{{ audit_format }}"
-
-## The following should not need changing
-audit_vars_path: "{{ audit_conf_dir }}/vars/{{ ansible_facts.hostname }}.yml"
-audit_results: |
-      The pre remediation results are: {{ pre_audit_summary }}.
-      The post remediation results are: {{ post_audit_summary }}.
-      Full breakdown can be found in {{ audit_out_dir }}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -75,9 +75,20 @@ audit_capture_files_dir: /some/location to copy to on control node
 # you will need to access to either github or the file already dowmloaded
 get_audit_binary_method: download
 
+## if get_audit_binary_method - copy the following needs to be updated for your environment
+## it is expected that it will be copied from somewhere accessible to the control node
+## e.g copy from ansible control node to remote host
+audit_bin_copy_location: /some/accessible/path
+
 # how to get audit files onto host options
 # options are git/copy/get_url other e.g. if you wish to run from already downloaded conf
 audit_content: git
+
+# archive or copy:
+audit_conf_copy: "some path to copy from"
+
+# get_url:
+audit_files_url: "some url maybe s3?"
 
 # Run heavy tests - some tests can have more impact on a system enabling these can have greater impact on a system
 audit_run_heavy_tests: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,7 +66,7 @@ run_audit: false
 audit_only: false
 # As part of audit_only
 # This will enable files to be copied back to control node
-capture_audit_files: false
+fetch_audit_files: false
 # Path to copy the files to will create dir structure
 audit_capture_files_dir: /some/location to copy to on control node
 

--- a/tasks/LE_audit_setup.yml
+++ b/tasks/LE_audit_setup.yml
@@ -5,12 +5,12 @@
       - name: Pre Audit Setup | Set audit package name | 64bit
         ansible.builtin.set_fact:
             audit_pkg_arch_name: AMD64
-        when: ansible_machine == "x86_64"
+        when: ansible_facts.machine == "x86_64"
 
       - name: Pre Audit Setup | Set audit package name | ARM64
         ansible.builtin.set_fact:
             audit_pkg_arch_name: ARM64
-        when: ansible_machine == "arm64"
+        when: ansible_facts.machine == "arm64"
 
 - name: Pre Audit Setup | Download audit binary
   ansible.builtin.get_url:

--- a/tasks/LE_audit_setup.yml
+++ b/tasks/LE_audit_setup.yml
@@ -1,22 +1,34 @@
 ---
 
+- name: Pre Audit Setup | Set audit package name
+  block:
+      - name: Pre Audit Setup | Set audit package name | 64bit
+        ansible.builtin.set_fact:
+            audit_pkg_arch_name: AMD64
+        when: ansible_machine == "x86_64"
+
+      - name: Pre Audit Setup | Set audit package name | ARM64
+        ansible.builtin.set_fact:
+            audit_pkg_arch_name: ARM64
+        when: ansible_machine == "arm64"
+
 - name: Pre Audit Setup | Download audit binary
   ansible.builtin.get_url:
-      url: "{{ audit_bin_url }}"
+      url: "{{ audit_bin_url }}{{ audit_pkg_arch_name }}"
       dest: "{{ audit_bin }}"
       owner: root
       group: root
-      checksum: "{{ audit_bin_version.checksum }}"
+      checksum: "{{ audit_bin_version[audit_pkg_arch_name + '_checksum'] }}"
       mode: '0555'
   when:
       - get_audit_binary_method == 'download'
 
-- name: Pre Audit Setup | copy audit binary
+- name: Pre Audit Setup | Copy audit binary
   ansible.builtin.copy:
       src: "{{ audit_bin_copy_location }}"
       dest: "{{ audit_bin }}"
+      mode: '0555'
       owner: root
       group: root
-      mode: '0555'
   when:
       - get_audit_binary_method == 'copy'

--- a/tasks/audit_only.yml
+++ b/tasks/audit_only.yml
@@ -6,7 +6,7 @@
       path: "{{ audit_capture_files_dir }}/{{ inventory_hostname }}"
       recurse: true
       state: directory
-  when: capture_audit_files
+  when: fetch_audit_files
   delegate_to: localhost
   become: false
 
@@ -16,7 +16,7 @@
       flat: true
       mode: '0644'
       src: "{{ pre_audit_outfile }}"
-  when: capture_audit_files
+  when: fetch_audit_files
 
 - name: Audit_only | Show Audit Summary
   when:

--- a/tasks/audit_only.yml
+++ b/tasks/audit_only.yml
@@ -1,0 +1,30 @@
+---
+
+- name: Audit_Only | Create local Directories for hosts
+  ansible.builtin.file:
+      mode: '0755'
+      path: "{{ audit_capture_files_dir }}/{{ inventory_hostname }}"
+      recurse: true
+      state: directory
+  when: capture_audit_files
+  delegate_to: localhost
+  become: false
+
+- name: Audit_only | Get audits from systems and put in group dir
+  ansible.builtin.fetch:
+      dest: "{{ audit_capture_files_dir }}/{{ inventory_hostname }}/"
+      flat: true
+      mode: '0644'
+      src: "{{ pre_audit_outfile }}"
+  when: capture_audit_files
+
+- name: Audit_only | Show Audit Summary
+  when:
+      - audit_only
+  ansible.builtin.debug:
+      msg: "The Audit results are: {{ pre_audit_summary }}."
+
+- name: Audit_only | Stop Playbook Audit Only selected
+  when:
+      - audit_only
+  ansible.builtin.meta: end_play

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -131,11 +131,20 @@
   tags:
       - always
 
-- name: Run pre-remediation audit
-  ansible.builtin.import_tasks:
-      file: pre_remediation_audit.yml
+- name: Include audit specific variables
+  ansible.builtin.include_vars: audit.yml
   when:
+      - run_audit or audit_only
+      - setup_audit
+  tags:
+      - setup_audit
       - run_audit
+
+- name: Include pre-remediation audit tasks
+  ansible.builtin.import_tasks: pre_remediation_audit.yml
+  when:
+      - run_audit or audit_only
+      - setup_audit
   tags:
       - run_audit
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: debug ansible_machine
+  ansible.builtin.debug:
+      var: ansible_machine
+
 - name: Check OS version and family
   ansible.builtin.fail:
       msg: "This role can only be run against Ubuntu 22. {{ ansible_facts.distribution }} {{ ansible_facts.distribution_major_version }} is not supported."

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: debug ansible_machine
   ansible.builtin.debug:
-      var: ansible_machine
+      var: ansible_facts.machine
 
 - name: Check OS version and family
   ansible.builtin.fail:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,17 +1,5 @@
 ---
 
-- name: Gather distribution info
-  # we need:
-  # - hardware for ansible_facts.mounts
-  # - platform for ansible_architecture (ansible internal)
-  # - virtual for ansible_facts.virtualization_type
-  ansible.builtin.setup:
-      gather_subset: distribution,hardware,platform,virtual,!all,!min
-  when:
-      - ansible_facts.distribution is not defined
-  tags:
-      - always
-
 - name: Check OS version and family
   ansible.builtin.fail:
       msg: "This role can only be run against Ubuntu 22. {{ ansible_facts.distribution }} {{ ansible_facts.distribution_major_version }} is not supported."

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,5 @@
 ---
 
-- name: debug ansible_machine
-  ansible.builtin.debug:
-      var: ansible_facts.machine
-
 - name: Check OS version and family
   ansible.builtin.fail:
       msg: "This role can only be run against Ubuntu 22. {{ ansible_facts.distribution }} {{ ansible_facts.distribution_major_version }} is not supported."

--- a/tasks/post_remediation_audit.yml
+++ b/tasks/post_remediation_audit.yml
@@ -1,52 +1,14 @@
 ---
 
-- name: Post Audit | Capture audit data if json format
-  block:
+- name: Post Audit | Run post_remediation {{ benchmark }} audit
+  ansible.builtin.shell: "{{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -o {{ post_audit_outfile }} -g {{ group_names }}"
+  changed_when: true
+  environment:
+      AUDIT_BIN: "{{ audit_bin }}"
+      AUDIT_CONTENT_LOCATION: "{{ audit_out_dir }}"
+      AUDIT_FILE: goss.yml
 
-      - name: "Post Audit | Run post_remediation {{ benchmark }} audit"
-        ansible.builtin.shell: "{{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -o {{ post_audit_outfile }} -g {{ group_names }}"
-        changed_when: true
-        environment:
-            AUDIT_BIN: "{{ audit_bin }}"
-            AUDIT_CONTENT_LOCATION: "{{ audit_out_dir }}"
-            AUDIT_FILE: "goss.yml"
-
-      - name: "Capture data {{ post_audit_outfile }}"
-        ansible.builtin.shell: "cat {{ post_audit_outfile }}"
-        register: post_audit
-        changed_when: false
-
-      - name: Capture post-audit result
-        ansible.builtin.set_fact:
-            post_audit_summary: "{{ post_audit.stdout | from_json | json_query(summary) }}"
-        vars:
-            summary: 'summary."summary-line"'
-  when:
-      - audit_format == "json"
-
-- name: Post Audit | Capture audit data if documentation format
-  block:
-
-      - name: "Post Audit | Run post_remediation {{ benchmark }} audit"
-        ansible.builtin.shell: "{{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -o {{ post_audit_outfile }} -g {{ group_names }} -f documentation"
-        changed_when: true
-        environment:
-            AUDIT_BIN: "{{ audit_bin }}"
-            AUDIT_CONTENT_LOCATION: "{{ audit_out_dir }}"
-            AUDIT_FILE: "goss.yml"
-
-      - name: "Post Audit | Capture data {{ post_audit_outfile }}"
-        ansible.builtin.shell: "tail -2 {{ post_audit_outfile }}"
-        register: post_audit
-        changed_when: false
-
-      - name: Post Audit | Capture post-audit result
-        ansible.builtin.set_fact:
-            post_audit_summary: "{{ post_audit.stdout_lines }}"
-  when:
-      - audit_format == "documentation"
-
-- name: Post Audit | Ensure audit files readable by users
+- name: Post Audit | ensure audit files readable by users
   ansible.builtin.file:
       path: "{{ item }}"
       mode: '0644'
@@ -54,3 +16,31 @@
   loop:
       - "{{ post_audit_outfile }}"
       - "{{ pre_audit_outfile }}"
+
+- name: Post Audit | Capture audit data if json format
+  when:
+      - audit_format == "json"
+  block:
+      - name: capture data {{ post_audit_outfile }}
+        ansible.builtin.shell: cat {{ post_audit_outfile }}
+        register: post_audit
+        changed_when: false
+
+      - name: Capture post-audit result
+        ansible.builtin.set_fact:
+            post_audit_summary: "{{ post_audit.stdout | from_json | json_query(summary) }}"
+        vars:
+            summary: summary."summary-line"
+
+- name: Post Audit | Capture audit data if documentation format
+  when:
+      - audit_format == "documentation"
+  block:
+      - name: Post Audit | capture data {{ post_audit_outfile }}
+        ansible.builtin.shell: tail -2 {{ post_audit_outfile }}
+        register: post_audit
+        changed_when: false
+
+      - name: Post Audit | Capture post-audit result
+        ansible.builtin.set_fact:
+            post_audit_summary: "{{ post_audit.stdout_lines }}"

--- a/tasks/pre_remediation_audit.yml
+++ b/tasks/pre_remediation_audit.yml
@@ -1,58 +1,58 @@
 ---
 
-- name: Audit Binary Setup | Setup the LE audit
-  ansible.builtin.include_tasks:
-      file: LE_audit_setup.yml
+- name: Pre Audit Setup | Setup the LE audit
   when:
       - setup_audit
   tags:
       - setup_audit
+  ansible.builtin.include_tasks: LE_audit_setup.yml
 
-- name: "Pre Audit Setup | Ensure {{ audit_conf_dir }} exists"
+- name: Pre Audit Setup | Ensure {{ audit_conf_dir }} exists
   ansible.builtin.file:
       path: "{{ audit_conf_dir }}"
       state: directory
       mode: '0755'
 
 - name: Pre Audit Setup | If using git for content set up
+  when:
+      - audit_content == 'git'
   block:
       - name: Pre Audit Setup | Install git
         ansible.builtin.package:
             name: git
             state: present
-        when: "'git' not in ansible_facts.packages"
 
-      - name: Pre Audit Setup | retrieve audit content files from git
+      - name: Pre Audit Setup | Retrieve audit content files from git
         ansible.builtin.git:
             repo: "{{ audit_file_git }}"
             dest: "{{ audit_conf_dir }}"
             version: "{{ audit_git_version }}"
-  when:
-      - audit_content == 'git'
 
-- name: Pre Audit Setup | copy to audit content files to server
+- name: Pre Audit Setup | Copy to audit content files to server
+  when:
+      - audit_content == 'copy'
   ansible.builtin.copy:
       src: "{{ audit_local_copy }}"
       dest: "{{ audit_conf_dest }}"
       mode: preserve
-  when:
-      - audit_content == 'copy'
 
-- name: Pre Audit Setup | unarchive audit content files on server
+- name: Pre Audit Setup | Unarchive audit content files on server
+  when:
+      - audit_content == 'archived'
   ansible.builtin.unarchive:
       src: "{{ audit_conf_copy  }}"
       dest: "{{ audit_conf_dir }}"
-  when:
-      - audit_content == 'archived'
 
-- name: Pre Audit Setup | get audit content from url
+- name: Pre Audit Setup | Get audit content from url
+  when:
+      - audit_content == 'get_url'
   ansible.builtin.get_url:
       url: "{{ audit_files_url }}"
       dest: "{{ audit_conf_dir }}"
-  when:
-      - audit_content == 'get_url'
 
 - name: Pre Audit Setup | Check Goss is available
+  when:
+      - run_audit
   block:
       - name: Pre Audit Setup | Check for goss file
         ansible.builtin.stat:
@@ -60,34 +60,36 @@
         register: goss_available
 
       - name: Pre Audit Setup | If audit ensure goss is available
+        when:
+            - not goss_available.stat.exists
         ansible.builtin.assert:
-            that: goss_available.stat.exists
             msg: "Audit has been selected: unable to find goss binary at {{ audit_bin }}"
-  when:
-      - run_audit
 
 - name: Pre Audit Setup | Copy ansible default vars values to test audit
+  tags:
+      - goss_template
+      - run_audit
+  when:
+      - run_audit
   ansible.builtin.template:
       src: ansible_vars_goss.yml.j2
       dest: "{{ audit_vars_path }}"
       mode: '0600'
-  when:
-      - run_audit
-  tags:
-      - goss_template
+
+- name: Pre Audit | Run pre_remediation {{ benchmark }} audit
+  ansible.builtin.shell: "{{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -o {{ pre_audit_outfile }} -g {{ group_names }}"
+  changed_when: true
+  environment:
+      AUDIT_BIN: "{{ audit_bin }}"
+      AUDIT_CONTENT_LOCATION: "{{ audit_out_dir }}"
+      AUDIT_FILE: goss.yml
 
 - name: Pre Audit | Capture audit data if json format
+  when:
+      - audit_format == "json"
   block:
-      - name: "Pre Audit | Run pre_remediation {{ benchmark }} audit"
-        ansible.builtin.shell: "{{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -o {{ pre_audit_outfile }} -g {{ group_names }}"
-        changed_when: true
-        environment:
-            AUDIT_BIN: "{{ audit_bin }}"
-            AUDIT_CONTENT_LOCATION: "{{ audit_out_dir }}"
-            AUDIT_FILE: "goss.yml"
-
-      - name: "capture data {{ pre_audit_outfile }}"
-        ansible.builtin.shell: "cat {{ pre_audit_outfile }}"
+      - name: capture data {{ pre_audit_outfile }}
+        ansible.builtin.shell: cat {{ pre_audit_outfile }}
         register: pre_audit
         changed_when: false
 
@@ -95,28 +97,22 @@
         ansible.builtin.set_fact:
             pre_audit_summary: "{{ pre_audit.stdout | from_json | json_query(summary) }}"
         vars:
-            summary: 'summary."summary-line"'
-  when:
-      - audit_format == "json"
+            summary: summary."summary-line"
 
 - name: Pre Audit | Capture audit data if documentation format
+  when:
+      - audit_format == "documentation"
   block:
-
-      - name: "Pre Audit | Run pre_remediation {{ benchmark }} audit"
-        ansible.builtin.shell: "{{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -o {{ pre_audit_outfile }} -g {{ group_names }} -f documentation"
-        changed_when: true
-        environment:
-            AUDIT_BIN: "{{ audit_bin }}"
-            AUDIT_CONTENT_LOCATION: "{{ audit_out_dir }}"
-            AUDIT_FILE: "goss.yml"
-
-      - name: "Pre Audit | capture data {{ pre_audit_outfile }} | documentation format"
-        ansible.builtin.shell: "tail -2 {{ pre_audit_outfile }}"
+      - name: Pre Audit | capture data {{ pre_audit_outfile }} | documentation format
+        ansible.builtin.shell: tail -2 {{ pre_audit_outfile }}
         register: pre_audit
         changed_when: false
 
       - name: Pre Audit | Capture pre-audit result | documentation format
         ansible.builtin.set_fact:
             pre_audit_summary: "{{ pre_audit.stdout_lines }}"
+
+- name: Audit_Only | Run Audit Only
   when:
-      - audit_format == "documentation"
+      - audit_only
+  ansible.builtin.import_tasks: audit_only.yml

--- a/vars/audit.yml
+++ b/vars/audit.yml
@@ -1,0 +1,52 @@
+---
+
+#### Audit Configuration Settings ####
+
+# Timeout for those cmds that take longer to run where timeout set
+audit_cmd_timeout: 120000
+
+# if get_audit_binary_method == download change accordingly
+audit_bin_url: "https://github.com/goss-org/goss/releases/download/{{ audit_bin_version.release }}/goss-linux-"
+
+## if get_audit_binary_method - copy the following needs to be updated for your environment
+## it is expected that it will be copied from somewhere accessible to the control node
+## e.g copy from ansible control node to remote host
+audit_bin_copy_location: /some/accessible/path
+
+### Goss Audit Benchmark file ###
+## managed by the control audit_content
+# git
+audit_file_git: "https://github.com/ansible-lockdown/{{ benchmark }}-Audit.git"
+audit_git_version: "benchmark-{{ benchmark_version }}"
+
+# archive or copy:
+audit_conf_copy: "some path to copy from"
+
+# get_url:
+audit_files_url: "some url maybe s3?"
+
+## Goss configuration information
+# Where the goss configs and outputs are stored
+audit_out_dir: '/opt'
+# Where the goss audit configuration will be stored
+audit_conf_dir: "{{ audit_out_dir }}/{{ benchmark }}-Audit"
+
+# If changed these can affect other products
+pre_audit_outfile: "{{ audit_out_dir }}/{{ ansible_facts.hostname }}-{{ benchmark }}-{{ benchmark_version }}_pre_scan_{{ ansible_facts.date_time.epoch }}.{{ audit_format }}"
+post_audit_outfile: "{{ audit_out_dir }}/{{ ansible_facts.hostname }}-{{ benchmark }}-{{ benchmark_version }}_post_scan_{{ ansible_facts.date_time.epoch }}.{{ audit_format }}"
+
+## The following should not need changing
+
+### Audit binary settings ###
+audit_bin_version:
+    release: v0.4.4
+    AMD64_checksum: 'sha256:1c4f54b22fde9d4d5687939abc2606b0660a5d14a98afcd09b04b793d69acdc5'
+audit_bin_path: /usr/local/bin/
+audit_bin: "{{ audit_bin_path }}goss"
+audit_format: json
+
+audit_vars_path: "{{ audit_conf_dir }}/vars/{{ ansible_facts.hostname }}.yml"
+audit_results: |
+      The pre remediation results are: {{ pre_audit_summary }}.
+      The post remediation results are: {{ post_audit_summary }}.
+      Full breakdown can be found in {{ audit_out_dir }}

--- a/vars/audit.yml
+++ b/vars/audit.yml
@@ -8,22 +8,11 @@ audit_cmd_timeout: 120000
 # if get_audit_binary_method == download change accordingly
 audit_bin_url: "https://github.com/goss-org/goss/releases/download/{{ audit_bin_version.release }}/goss-linux-"
 
-## if get_audit_binary_method - copy the following needs to be updated for your environment
-## it is expected that it will be copied from somewhere accessible to the control node
-## e.g copy from ansible control node to remote host
-audit_bin_copy_location: /some/accessible/path
-
 ### Goss Audit Benchmark file ###
 ## managed by the control audit_content
 # git
 audit_file_git: "https://github.com/ansible-lockdown/{{ benchmark }}-Audit.git"
 audit_git_version: "benchmark-{{ benchmark_version }}"
-
-# archive or copy:
-audit_conf_copy: "some path to copy from"
-
-# get_url:
-audit_files_url: "some url maybe s3?"
 
 ## Goss configuration information
 # Where the goss configs and outputs are stored


### PR DESCRIPTION
**Overall Review of Changes:**
Added ability with select vars to run only the audit using the remediate playbook
- updated goss binary to 0.4.4
- moved majority of audit variables to vars/audit.yml
- new function to enable audit_only using remediation
- removed some dupes in audit config

**How has this been tested?:**
Manually, with and without the options set

