### PR TITLE
missing grub check fails when using sysctl

### DIFF
--- a/tasks/section_3/cis_3.1.x.yml
+++ b/tasks/section_3/cis_3.1.x.yml
@@ -26,6 +26,7 @@
             line: '\1 ipv6.disable=1"'
             backrefs: true
         when:
+            - ubtu22cis_ipv6_disable == 'grub'
             - ipv6disable_replaced is not changed
             - "'ipv6.disable' not in ubtu22cis_3_1_1_cmdline_settings.stdout"
         notify: Grub update


### PR DESCRIPTION
**Overall Review of Changes:**
added missing conditional

**Issue Fixes:**
missing grub check fails when using sysctl

**Enhancements:**
n/a

**How has this been tested?:**
tested locally
