### PR TITLE
Fixes 4.1.3.6 to match CIS v1.0.0 benchmark

### DIFF
--- a/tasks/section_4/cis_4.1.3.x.yml
+++ b/tasks/section_4/cis_4.1.3.x.yml
@@ -70,7 +70,7 @@
 - name: "4.1.3.6 | PATCH | Ensure use of privileged commands is collected"
   block:
       - name: "4.1.3.6 | AUDIT | Ensure use of privileged commands is collected | Get list of privileged programs"
-        ansible.builtin.shell: for i in  $(findmnt -n -l -k -it $(awk '/nodev/ { print $2 }' /proc/filesystems | paste -sd,) | grep -Pv "noexec|nosuid" | awk '{print $1}'); do find $i -xdev -type f -perm -4000 -o -type f -perm -2000 2>/dev/null; done | grep -vw '/snap'
+        ansible.builtin.shell: for i in  $(findmnt -n -l -k -it $(awk '/nodev/ { print $2 }' /proc/filesystems | paste -sd,) | grep -Pv "noexec|nosuid" | awk '{print $1}'); do find $i -xdev -type f -perm -4000 -o -type f -perm -2000 2>/dev/null; done
         register: priv_procs
         changed_when: false
         check_mode: false


### PR DESCRIPTION
**Overall Review of Changes:**
Fixed 4.1.3.6 to match CIS v1.0.0 benchmark.  /snap can have privileged commands and should not be excluded from collection.  All audit scanners are looking at /snap  as part of the system.

**Issue Fixes:**
removes the grep -v /snap as this deviates from CIS benchmark

**Enhancements:**
N/A

**How has this been tested?:**
tested locally
