### PR TITLE
Fixes missing executable bit on grub config files.

### DIFF
--- a/tasks/section_1/cis_1.4.x.yml
+++ b/tasks/section_1/cis_1.4.x.yml
@@ -18,7 +18,7 @@
         dest: "{{ ubtu22cis_grub_user_file }}"
         owner: root
         group: root
-        mode: 'go-w'
+        mode: 'go-w,u+x'
       notify: Grub update
 
     - name: "1.4.1 | PATCH | Ensure bootloader password is set | allow unrestricted boot"


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
added the executable bit to the 00_user file to get it to compile

**Issue Fixes:**
No issue file.  From the README in the grub dir:
"All **executable** files in this directory are processed in shell expansion order."

**Enhancements:**
bug fix

**How has this been tested?:**
Tested on local machines.
