### PR TITLE
fixes broken systemd reload notify

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -159,7 +159,7 @@
     name: "{{ ubtu22cis_time_sync_tool }}"
     state: restarted
 
-- name: Reload systemctl
+- name: Systemd_daemon_reload
   ansible.builtin.systemd:
     daemon_reload: true
 

--- a/tasks/section_1/cis_1.5.x.yml
+++ b/tasks/section_1/cis_1.5.x.yml
@@ -74,7 +74,7 @@
         owner: root
         group: root
         mode: 'go-wx'
-      notify: Reload systemctl
+      notify: Systemd_daemon_reload
 
     - name: "1.5.3 | PATCH | Ensure core dumps are restricted | coredump.conf"
       ansible.builtin.lineinfile:


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
notify in 1.5.x are set to a name that doesn't exist.  Name correction to the systemd reload

**Issue Fixes:**
systemd reload works now.

**Enhancements:**
bug fix

**How has this been tested?:**
tested locally
