### PR TITLE
fix: unable to configure AIDE with systemd

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1135,7 +1135,6 @@ ubtu22cis_aide_cron_month: '*'
 # can be concatenated with commas.
 ubtu22cis_aide_cron_weekday: '*'
 
-
 # This variable represents the actual command or script that the systemd timer
 # will execute for running AIDE in update mode.
 ubtu22cis_aide_systemd_exec: '/usr/bin/aide --config /etc/aide/aide.conf --update'
@@ -1166,7 +1165,6 @@ ubtu22cis_aide_systemd_month: '*'
 # can be given in the range `0-7` (both `0` and `7` represent Sunday); several weekdays
 # can be concatenated with commas.
 ubtu22cis_aide_systemd_weekday: '*'
-
 
 ## Controls 6.2.1.x journald
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1135,6 +1135,39 @@ ubtu22cis_aide_cron_month: '*'
 # can be concatenated with commas.
 ubtu22cis_aide_cron_weekday: '*'
 
+
+# This variable represents the actual command or script that the systemd timer
+# will execute for running AIDE in update mode.
+ubtu22cis_aide_systemd_exec: '/usr/bin/aide --config /etc/aide/aide.conf --update'
+
+# These variables define the schedule for the systemd timer job
+# This variable governs the minute of the time of day when the AIDE systemd timer is run.
+# It must be in the range `0-59`.
+ubtu22cis_aide_systemd_minute: 0
+
+# This variable governs the hour of the time of day when the AIDE systemd timer is run.
+# It must be in the range `0-23`.
+ubtu22cis_aide_systemd_hour: 5
+
+# This variable governs the day of the month when the AIDE systemd timer is run.
+# `*` signifies that the job is run on all days; furthermore, specific days
+# can be given in the range `1-31`; several days can be concatenated with a comma.
+# The specified day(s) must be in the range `1-31`.
+ubtu22cis_aide_systemd_day: '*'
+
+# This variable governs months when the AIDE systemd timer is run.
+# `*` signifies that the job is run in every month; furthermore, specific months
+# can be given in the range `1-12`; several months can be concatenated with commas.
+# The specified month(s) must be in the range `1-12`.
+ubtu22cis_aide_systemd_month: '*'
+
+# This variable governs the weekdays when the AIDE systemd timer is run.
+# `*` signifies that the job is run on all weekdays; furthermore, specific weekdays
+# can be given in the range `0-7` (both `0` and `7` represent Sunday); several weekdays
+# can be concatenated with commas.
+ubtu22cis_aide_systemd_weekday: '*'
+
+
 ## Controls 6.2.1.x journald
 
 # This variable specifies the address of the remote log host where logs are being sent.

--- a/templates/etc/systemd/system/aidecheck.service.j2
+++ b/templates/etc/systemd/system/aidecheck.service.j2
@@ -3,7 +3,7 @@ Description=Aide Check
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/aide.wrapper --config /etc/aide/aide.conf --update
+ExecStart={{ ubtu22cis_aide_systemd_exec }}
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/etc/systemd/system/aidecheck.timer.j2
+++ b/templates/etc/systemd/system/aidecheck.timer.j2
@@ -2,7 +2,7 @@
 Description=Aide check
 
 [Timer]
-OnCalendar={{ ubtu22cis_aide_cron.aide_day }}-{{ ubtu22cis_aide_cron.aide_month }}-{{ ubtu22cis_aide_cron.aide_weekday }} {{ ubtu22cis_aide_cron.aide_hour }}:{{ ubtu22cis_aide_cron.aide_minute }}:00
+OnCalendar={{ ubtu22cis_aide_cron.aide_day | default(ubtu22cis_aide_systemd_day, true) }}-{{ ubtu22cis_aide_cron.aide_month | default(ubtu22cis_aide_systemd_month, true) }}-{{ ubtu22cis_aide_cron.aide_weekday | default(ubtu22cis_aide_systemd_weekday, true) }} {{ ubtu22cis_aide_cron.aide_hour | default(ubtu22cis_aide_systemd_hour, true) }}:{{ ubtu22cis_aide_cron.aide_minute | default(ubtu22cis_aide_systemd_minute, true) }}:00
 Unit=aidecheck.service
 
 [Install]


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**

1. Added systemd timer configuration variables for AIDE

   Introduced configurable parameters for AIDE systemd timer execution, including command path and scheduling fields (minute, hour, day, month, weekday).

1. Refactored aidecheck.service.j2

   Replaced hardcoded ExecStart path with a configurable variable to improve flexibility and maintainability.

1. Refactored aidecheck.timer.j2

   Applied Jinja default filters to all OnCalendar parameters, ensuring fallback to systemd defaults when cron variables are unset.

**Issue Fixes:**

Closes: #313 

**Enhancements:**

None

**How has this been tested?:**

Applied in local system VM image build pipeline

