### PR TITLE
Fix changed issue

### DIFF
--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -168,7 +168,7 @@
     modification_time: preserve
     access_time: preserve
   register: prelim_pwquality_dummy
-  changed_when: prelim_pwquality_dummy.diff == "absent"
+  changed_when: prelim_pwquality_dummy.changed
   loop:
     - { path: '/etc/security/pwquality.conf.d', state: 'directory' }
     - { path: '/etc/security/pwquality.conf.d/cis_dummy.conf', state: 'touch' }


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed


**Issue Fixes:**
I got an issue with prelim because of the changed_when condition that is a dict and should be a string to be compared to "absent".
```
TASK [ubuntu22-cis : PRELIM | PATCH | Ensure conf.d directory exists required for 5.3.3.2.x] ********************************************************************
[ERROR]: Task failed: Action failed: Unknown error.
Origin: /Users/fponchon/code/infrastructure/michelin-ansible/roles/ubuntu22-cis/tasks/prelim.yml:153:3

151   register: prelim_pam_conf_files
152
153 - name: PRELIM | PATCH | Ensure conf.d directory exists required for 5.3.3.2.x
      ^ column 3

failed: [localhost] (item={'path': '/etc/security/pwquality.conf.d', 'state': 'directory'}) => {"ansible_loop_var": "item", "changed": false, "changed_when_result": "Error while evaluating conditional: object of type 'dict' has no attribute 'diff'", "gid": 0, "group": "root", "item": {"path": "/etc/security/pwquality.conf.d", "state": "directory"}, "mode": "0750", "msg": "Task failed: Action failed: Unknown error.", "owner": "root", "path": "/etc/security/pwquality.conf.d", "size": 4096, "state": "directory", "uid": 0}
failed: [localhost] (item={'path': '/etc/security/pwquality.conf.d/cis_dummy.conf', 'state': 'touch'}) => {"ansible_loop_var": "item", "changed": false, "changed_when_result": "Error while evaluating conditional: object of type 'dict' has no attribute 'diff'", "dest": "/etc/security/pwquality.conf.d/cis_dummy.conf", "gid": 0, "group": "root", "item": {"path": "/etc/security/pwquality.conf.d/cis_dummy.conf", "state": "touch"}, "mode": "0640", "msg": "Task failed: Action failed: Unknown error.", "owner": "root", "size": 0, "state": "file", "uid": 0}
```
In order to fix, i propose to use "changed" attributes of the result in the same task.
```
TASK [ubuntu22-cis : PRELIM | PATCH | Ensure conf.d directory exists required for 5.3.3.2.x] ********************************************************************
ok: [localhost] => (item={'path': '/etc/security/pwquality.conf.d', 'state': 'directory'}) => {"ansible_loop_var": "item", "changed": false, "gid": 0, "group": "root", "item": {"path": "/etc/security/pwquality.conf.d", "state": "directory"}, "mode": "0750", "owner": "root", "path": "/etc/security/pwquality.conf.d", "size": 4096, "state": "directory", "uid": 0}
```

**How has this been tested?:**
It have been test on a VM on with a fresh Ubuntu 22.04.
