### PR TITLE
fix: 🐛 handle 'all' in outbound ports loop in rule rule_4.1.5 and `apt/dpkg` lock

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -631,6 +631,10 @@ ubtu22cis_desktop_required: false
 # This will also purge any packages not removed via this playbook
 ubtu22cis_purge_apt: false
 
+## Apt/dpkg lock timeout (seconds)
+# Wait time for apt/dpkg frontend lock to clear before failing package tasks.
+ubtu22cis_apt_lock_timeout: 180
+
 ## Ignore change_when for apt update task
 # Modifies behavior of 'changed_when' for 'apt update' task  in prelim that always changes
 ubtu22cis_ignore_apt_update_changed_when: false

--- a/tasks/section_4/cis_4.1.x.yml
+++ b/tasks/section_4/cis_4.1.x.yml
@@ -112,7 +112,7 @@
         direction: out
         proto: "{{ item.proto }}"
         to_port: '{{ item.port }}'
-      loop: "{{ ubtu22cis_ufw_allow_out_ports }}"
+      loop: "{{ ubtu22cis_ufw_allow_out_ports if ubtu22cis_ufw_allow_out_ports != 'all' else [] }}"
       loop_control:
         label: "{{ item.port }}"
       notify: Reload ufw

--- a/tasks/section_5/cis_5.3.1.x.yml
+++ b/tasks/section_5/cis_5.3.1.x.yml
@@ -15,6 +15,7 @@
   ansible.builtin.package:
     name: libpam-runtime
     state: latest
+    lock_timeout: "{{ ubtu22cis_apt_lock_timeout }}"
 
 - name: "5.3.1.2 | PATCH | Ensure libpam-modules is installed"
   when:
@@ -31,6 +32,7 @@
   ansible.builtin.package:
     name: libpam-modules
     state: latest
+    lock_timeout: "{{ ubtu22cis_apt_lock_timeout }}"
 
 - name: "5.3.1.3 | PATCH | Ensure libpam-pwquality is installed"
   when:
@@ -46,3 +48,4 @@
   ansible.builtin.package:
     name: libpam-pwquality
     state: latest
+    lock_timeout: "{{ ubtu22cis_apt_lock_timeout }}"

--- a/tasks/section_5/cis_5.3.1.x.yml
+++ b/tasks/section_5/cis_5.3.1.x.yml
@@ -12,7 +12,7 @@
     - pam
     - rule_5.3.1.1
     - NIST800-53R5_NA
-  ansible.builtin.package:
+  ansible.builtin.apt:
     name: libpam-runtime
     state: latest
     lock_timeout: "{{ ubtu22cis_apt_lock_timeout }}"
@@ -29,7 +29,7 @@
     - pam
     - rule_5.3.1.2
     - NIST800-53R5_NA
-  ansible.builtin.package:
+  ansible.builtin.apt:
     name: libpam-modules
     state: latest
     lock_timeout: "{{ ubtu22cis_apt_lock_timeout }}"
@@ -45,7 +45,7 @@
     - pam
     - rule_5.3.1.3
     - NIST800-53R5_NA
-  ansible.builtin.package:
+  ansible.builtin.apt:
     name: libpam-pwquality
     state: latest
     lock_timeout: "{{ ubtu22cis_apt_lock_timeout }}"


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**

- Changed `tasks/section_4/cis_4.1.x.yml` so the loop in the `4.1.5 "Custom ports"` task uses an empty list when `ubtu22cis_ufw_allow_out_ports == 'all'`, instead of looping over the raw value.
- Added a configurable ubtu22cis_apt_lock_timeout (default 180s) and applied it to the CIS 5.3.1 package installs to wait for apt/dpkg locks instead of failing. 

**Issue Fixes:**
Closes: #328 
Closes: #330 

**Enhancements:**
N/A

**How has this been tested?:**
Local image builder

