### PR TITLE
stop and mask only when present

### DIFF
--- a/tasks/section_2/cis_2.1.x.yml
+++ b/tasks/section_2/cis_2.1.x.yml
@@ -28,9 +28,8 @@
         - ubtu22cis_autofs_mask
       ansible.builtin.systemd:
         name: autofs
-        enabled: false
-        state: stopped
-        masked: true
+        enabled: "{{ ('autofs' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('autofs' in ansible_facts.packages) | ternary('stopped', omit) }}"
       notify: Systemd_daemon_reload
 
 - name: "2.1.2 | PATCH | Ensure avahi daemon services are not in use"
@@ -61,8 +60,8 @@
         - ubtu22cis_avahi_mask
       ansible.builtin.systemd:
         name: "{{ item }}"
-        enabled: false
-        state: stopped
+        enabled: "{{ ('avahi' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('avahi' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
       loop:
         - avahi-daemon.socket
@@ -95,8 +94,8 @@
         - ubtu22cis_dhcp_mask
       ansible.builtin.systemd:
         name: "{{ item }}"
-        enabled: false
-        state: stopped
+        enabled: "{{ ('isc-dhcp-server' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('isc-dhcp-server' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
       loop:
         - isc-dhcp-server.service
@@ -129,8 +128,8 @@
         - ubtu22cis_dns_mask
       ansible.builtin.systemd:
         name: named.service
-        enabled: false
-        state: stopped
+        enabled: "{{ ('bind9' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('bind9' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
       notify: Systemd_daemon_reload
 
@@ -160,8 +159,8 @@
         - ubtu22cis_dnsmasq_mask
       ansible.builtin.systemd:
         name: dnsmasq.service
-        enabled: false
-        state: stopped
+        enabled: "{{ ('dnsmasq' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('dnsmasq' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
       notify: Systemd_daemon_reload
 
@@ -192,8 +191,8 @@
         - ubtu22cis_ftp_mask
       ansible.builtin.systemd:
         name: vsftpd.service
-        enabled: false
-        state: stopped
+        enabled: "{{ ('vsftpd' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('vsftpd' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
       notify: Systemd_daemon_reload
 
@@ -223,8 +222,8 @@
         - ubtu22cis_ldap_mask
       ansible.builtin.systemd:
         name: slapd.service
-        enabled: false
-        state: stopped
+        enabled: "{{ ('slapd' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('slapd' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
       notify: Systemd_daemon_reload
 
@@ -258,8 +257,8 @@
         - ubtu22cis_message_mask
       ansible.builtin.systemd:
         name: "{{ item }}"
-        enabled: false
-        state: stopped
+        enabled: "{{ (('dovecot-pop3d' in ansible_facts.packages) | ('dovecot-imapd' in ansible_facts.packages)) | ternary(false, omit) }}"
+        state: "{{ (('dovecot-pop3d' in ansible_facts.packages) | ('dovecot-imapd' in ansible_facts.packages)) | ternary('stopped', omit) }}"
         masked: true
       loop:
         - "dovecot.socket"
@@ -294,8 +293,8 @@
         - ubtu22cis_nfs_mask
       ansible.builtin.systemd:
         name: nfs-server.service
-        enabled: false
-        state: stopped
+        enabled: "{{ ('nfs-kernel-server' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('nfs-kernel-server' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
       notify: Systemd_daemon_reload
 
@@ -326,8 +325,8 @@
         - ubtu22cis_nis_mask
       ansible.builtin.systemd:
         name: ypserv.service
-        enabled: false
-        state: stopped
+        enabled: "{{ ('ypserv' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('ypserv' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
       notify: Systemd_daemon_reload
 
@@ -356,8 +355,8 @@
         - ubtu22cis_print_mask
       ansible.builtin.systemd:
         name: "{{ item }}"
-        enabled: false
-        state: stopped
+        enabled: "{{ ('cups' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('cups' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
       loop:
         - "cups.socket"
@@ -391,8 +390,8 @@
         - ubtu22cis_rpc_mask
       ansible.builtin.systemd:
         name: "{{ item }}"
-        enabled: false
-        state: stopped
+        enabled: "{{ ('rpcbind' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('rpcbind' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
       loop:
         - rpcbind.service
@@ -425,8 +424,8 @@
         - ubtu22cis_rsync_mask
       ansible.builtin.systemd:
         name: rsyncd.service
-        enabled: false
-        state: stopped
+        enabled: "{{ ('rsync' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('rsync' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
       notify: Systemd_daemon_reload
 
@@ -458,8 +457,8 @@
         - ubtu22cis_samba_mask
       ansible.builtin.systemd:
         name: smbd.service
-        enabled: false
-        state: stopped
+        enabled: "{{ ('samba' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('samba' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
       notify: Systemd_daemon_reload
 
@@ -491,8 +490,8 @@
         - ubtu22cis_snmp_mask
       ansible.builtin.systemd:
         name: snmpd.service
-        enabled: false
-        state: stopped
+        enabled: "{{ ('snmpd' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('snmpd' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
       notify: Systemd_daemon_reload
 
@@ -522,8 +521,8 @@
         - ubtu22cis_tftp_mask
       ansible.builtin.systemd:
         name: tftpd-hpa.service
-        enabled: false
-        state: stopped
+        enabled: "{{ ('tftpd-hpa' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('tftpd-hpa' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
       notify: Systemd_daemon_reload
 
@@ -553,8 +552,8 @@
         - ubtu22cis_squid_mask
       ansible.builtin.systemd:
         name: squid.service
-        enabled: false
-        state: stopped
+        enabled: "{{ ('squid' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('squid' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
       notify: Systemd_daemon_reload
 
@@ -597,8 +596,8 @@
         - "'apache2' in ansible_facts.packages"
       ansible.builtin.systemd:
         name: "{{ item }}"
-        enabled: false
-        state: stopped
+        enabled: "{{ ('apache2' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('apache2' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
       loop:
         - apache2.service
@@ -612,8 +611,8 @@
         - "'nginx' in ansible_facts.packages"
       ansible.builtin.systemd:
         name: ngnix.service
-        enabled: false
-        state: stopped
+        enabled: "{{ ('nginx' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('nginx' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
       notify: Systemd_daemon_reload
 
@@ -643,9 +642,9 @@
         - ubtu22cis_xinetd_mask
       ansible.builtin.systemd:
         name: xinetd.service
-        enabled: false
+        enabled: "{{ ('xinetd' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('xinetd' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
-        state: stopped
       notify: Systemd_daemon_reload
 
 - name: "2.1.20 | PATCH | Ensure X window server services are not in use"

--- a/tasks/section_2/cis_2.3.1.x.yml
+++ b/tasks/section_2/cis_2.3.1.x.yml
@@ -37,8 +37,8 @@
         - item != ubtu22cis_time_sync_tool
       ansible.builtin.service:
         name: "{{ item }}"
-        enabled: "{{ ( {{ item }} in ansible_facts.packages) | ternary(false, omit) }}"
-        state: "{{ ( {{ item }} in ansible_facts.packages) | ternary('stopped', omit) }}"
+        enabled: "{{ ( item in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ( item in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
         daemon_reload: true
       loop:

--- a/tasks/section_2/cis_2.3.1.x.yml
+++ b/tasks/section_2/cis_2.3.1.x.yml
@@ -1,7 +1,8 @@
 ---
 
 - name: "2.3.1.1 | PATCH | Ensure a single time synchronization daemon is in use"
-  when: ubtu22cis_rule_2_3_1_1
+  when:
+    - ubtu22cis_rule_2_3_1_1
   tags:
     - level1-server
     - level1-workstation
@@ -19,21 +20,28 @@
         state: present
 
     - name: "2.3.1.1 | PATCH | Ensure a single time synchronization daemon is in use | other pkgs removed"
-      when: item != ubtu22cis_time_sync_tool
+      when:
+        - item != ubtu22cis_time_sync_tool
       ansible.builtin.package:
         name: "{{ item }}"
         state: absent
       loop:
         - chrony
         - ntp
+        - systemd-timesyncd
 
+   # note this is somewhat redundant with tasking from 2.3.2 and 2.3.3 but since they can all be run individually
+   # to suite ones needs, its fine to have this stop disable and mask code both here and there
     - name: "2.3.1.1 | PATCH | Ensure a single time synchronization daemon is in use | mask service"
       when:
-        - ubtu22cis_time_sync_tool != "systemd-timesyncd"
-        - "'systemd-timesyncd' in ansible_facts.packages"
+        - item != ubtu22cis_time_sync_tool
       ansible.builtin.service:
-        name: systemd-timesyncd
-        state: stopped
-        enabled: false
+        name: "{{ item }}"
+        enabled: "{{ ( {{ item }} in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ( {{ item }} in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
         daemon_reload: true
+      loop:
+        - chrony
+        - ntp
+        - systemd-timesyncd

--- a/tasks/section_2/cis_2.3.2.x.yml
+++ b/tasks/section_2/cis_2.3.2.x.yml
@@ -50,14 +50,14 @@
       when: "'chrony' in ansible_facts.packages"
       ansible.builtin.systemd:
         name: chrony
-        state: stopped
-        enabled: false
+        enabled: "{{ ('chrony' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('chrony' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
 
     - name: "2.3.2.2 | PATCH | Ensure systemd-timesyncd is enabled and running | disable other time sources | ntp"
       when: "'ntp' in ansible_facts.packages"
       ansible.builtin.systemd:
         name: ntp
-        state: stopped
-        enabled: false
+        enabled: "{{ ('ntp' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('ntp' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true

--- a/tasks/section_2/cis_2.3.3.x.yml
+++ b/tasks/section_2/cis_2.3.3.x.yml
@@ -63,14 +63,14 @@
       when: "'systemd-timesyncd' in ansible_facts.packages"
       ansible.builtin.systemd:
         name: systemd-timesyncd
-        state: stopped
-        enabled: false
+        enabled: "{{ ('systemd-timesyncd' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('systemd-timesyncd' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
 
     - name: "2.3.3.3 | PATCH | Ensure chrony is enabled and running | disable other time sources | ntpd"
       when: "'ntpd' in ansible_facts.packages"
       ansible.builtin.systemd:
         name: ntpd
-        state: stopped
-        enabled: false
+        enabled: "{{ ('ntpd' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('ntpd' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true

--- a/tasks/section_3/cis_3.1.x.yml
+++ b/tasks/section_3/cis_3.1.x.yml
@@ -116,6 +116,6 @@
       notify: Systemd_daemon_reload
       ansible.builtin.systemd:
         name: bluetooth.service
-        enabled: false
-        state: stopped
+        enabled: "{{ ('bluez' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('bluez' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true

--- a/tasks/section_6/cis_6.2.1.2.x.yml
+++ b/tasks/section_6/cis_6.2.1.2.x.yml
@@ -72,8 +72,8 @@
     - NIST800-53R5_AU-12
   ansible.builtin.systemd:
     name: "{{ item }}"
-    state: stopped
-    enabled: false
+    enabled: "{{ ('systemd-journal-remote' in ansible_facts.packages) | ternary(false, omit) }}"
+    state: "{{ ('systemd-journal-remote' in ansible_facts.packages) | ternary('stopped', omit) }}"
     masked: true
   loop:
     - systemd-journal-remote.socket


### PR DESCRIPTION
**Overall Review of Changes:**
updated all mask task stop and disable args to stop and disable when package that delivers the service is present and be omitted when the package delivering the service is not present

**Issue Fixes:**
related to https://github.com/ansible-lockdown/RHEL9-CIS/pull/435 fix for https://github.com/ansible-lockdown/RHEL9-CIS/issues/434

**How has this been tested?:**
N/A

