### PR TITLE
fix(tasks): correct mount audit logic and variable naming in section 1

### DIFF
--- a/tasks/section_1/cis_1.1.2.1.x.yml
+++ b/tasks/section_1/cis_1.1.2.1.x.yml
@@ -22,12 +22,12 @@
       register: discovered_tmp_mount
 
     - name: "1.1.2.1.1 | AUDIT | Ensure /tmp is a separate partition | Absent"
-      when: discovered_tmp_mount is undefined
+      when: discovered_tmp_mount.rc != 0
       ansible.builtin.debug:
         msg: "Warning!! {{ required_mount }} is not mounted on a separate partition"
 
     - name: "1.1.2.1.1 | AUDIT | Ensure /tmp is a separate partition | Present"
-      when: discovered_tmp_mount is undefined
+      when: discovered_tmp_mount.rc != 0
       ansible.builtin.import_tasks:
         file: warning_facts.yml
 

--- a/tasks/section_1/cis_1.1.2.2.x.yml
+++ b/tasks/section_1/cis_1.1.2.2.x.yml
@@ -22,12 +22,12 @@
       register: discovered_dev_shm_mount
 
     - name: "1.1.2.2.1 | AUDIT | Ensure /dev/shm is a separate partition | Absent"
-      when: discovered_dev_shm_mount is undefined
+      when: discovered_dev_shm_mount.rc != 0
       ansible.builtin.debug:
         msg: "Warning!! {{ required_mount }} is not mounted on a separate partition"
 
     - name: "1.1.2.2.1 | AUDIT | Ensure /dev/shm is a separate partition | Present"
-      when: discovered_dev_shm_mount is undefined
+      when: discovered_dev_shm_mount.rc != 0
       ansible.builtin.import_tasks:
         file: warning_facts.yml
 

--- a/tasks/section_1/cis_1.1.2.3.x.yml
+++ b/tasks/section_1/cis_1.1.2.3.x.yml
@@ -21,12 +21,12 @@
       register: discovered_home_mount
 
     - name: "1.1.2.3.1 | AUDIT | Ensure /home is a separate partition | Absent"
-      when: discovered_dev_shm_mount is undefined
+      when: discovered_home_mount.rc != 0
       ansible.builtin.debug:
         msg: "Warning!! {{ required_mount }} is not mounted on a separate partition"
 
     - name: "1.1.2.3.1 | AUDIT | Ensure /home is a separate partition | Present"
-      when: discovered_dev_shm_mount is undefined
+      when: discovered_home_mount.rc != 0
       ansible.builtin.import_tasks:
         file: warning_facts.yml
 

--- a/tasks/section_1/cis_1.1.2.4.x.yml
+++ b/tasks/section_1/cis_1.1.2.4.x.yml
@@ -22,12 +22,12 @@
       register: discovered_var_mount
 
     - name: "1.1.2.4.1 | AUDIT | Ensure /var is a separate partition | Absent"
-      when: discovered_dev_shm_mount is undefined
+      when: discovered_var_mount.rc != 0
       ansible.builtin.debug:
         msg: "Warning!! {{ required_mount }} is not mounted on a separate partition"
 
     - name: "1.1.2.4.1 | AUDIT | Ensure /var is a separate partition | Present"
-      when: discovered_dev_shm_mount is undefined
+      when: discovered_var_mount.rc != 0
       ansible.builtin.import_tasks:
         file: warning_facts.yml
 

--- a/tasks/section_1/cis_1.1.2.5.x.yml
+++ b/tasks/section_1/cis_1.1.2.5.x.yml
@@ -22,12 +22,12 @@
       register: discovered_var_tmp_mount
 
     - name: "1.1.2.5.1 | AUDIT | Ensure /var/tmp is a separate partition | Absent"
-      when: discovered_var_tmp_mount is undefined
+      when: discovered_var_tmp_mount.rc != 0
       ansible.builtin.debug:
         msg: "Warning!! {{ required_mount }} is not mounted on a separate partition"
 
     - name: "1.1.2.5.1 | AUDIT | Ensure /var/tmp is a separate partition | Present"
-      when: discovered_var_tmp_mount is undefined
+      when: discovered_var_tmp_mount.rc != 0
       ansible.builtin.import_tasks:
         file: warning_facts.yml
 

--- a/tasks/section_1/cis_1.1.2.6.x.yml
+++ b/tasks/section_1/cis_1.1.2.6.x.yml
@@ -22,12 +22,12 @@
       register: discovered_var_log_mount
 
     - name: "1.1.2.6.1 | AUDIT | Ensure /var/log is a separate partition | Absent"
-      when: discovered_var_log_mount is undefined
+      when: discovered_var_log_mount.rc != 0
       ansible.builtin.debug:
         msg: "Warning!! {{ required_mount }} is not mounted on a separate partition"
 
     - name: "1.1.2.6.1 | AUDIT | Ensure /var/log is a separate partition | Present"
-      when: discovered_var_log_mount is undefined
+      when: discovered_var_log_mount.rc != 0
       ansible.builtin.import_tasks:
         file: warning_facts.yml
 

--- a/tasks/section_1/cis_1.1.2.7.x.yml
+++ b/tasks/section_1/cis_1.1.2.7.x.yml
@@ -22,12 +22,12 @@
       register: discovered_var_log_audit_mount
 
     - name: "1.1.2.7.1 | AUDIT | Ensure /var/log/audit is a separate partition | Absent"
-      when: discovered_var_log_audit_mount is undefined
+      when: discovered_var_log_audit_mount.rc != 0
       ansible.builtin.debug:
         msg: "Warning!! {{ required_mount }} is not mounted on a separate partition"
 
     - name: "1.1.2.7.1 | AUDIT | Ensure /var/log/audit is a separate partition | Present"
-      when: discovered_var_log_audit_mount is undefined
+      when: discovered_var_log_audit_mount.rc != 0
       ansible.builtin.import_tasks:
         file: warning_facts.yml
 


### PR DESCRIPTION
**Overall Review of Changes:**
This PR corrects critical logical errors and variable naming inconsistencies in the partition audit tasks of Section 1 (Benchmarks `1.1.2.1.x` through `1.1.2.7.x`). 
1. **Variable naming:** Fixed copy-paste errors where tasks for `/home` and `/var` incorrectly referenced `discovered_dev_shm_mount` instead of their own registered variables.
2. **Logic fix:** Changed the check from `is undefined` to `.rc != 0`. Since the preceding `command` task uses `register`, the variable is always defined, which previously caused the audit warnings to be skipped entirely.

**Issue Fixes:**
N/A (Found during manual code review and verified via testing)

**Enhancements:**
* Improved reliability of the audit summary by ensuring that missing partitions are correctly detected and added to the `warn_control_list`.
* Standardized the audit check pattern across all mount-related tasks in Section 1.

**How has this been tested?:**
Verified using a dedicated test playbook on an Ubuntu 22.04 VM. 
* **Scenario A (Missing partition):** Confirmed that `findmnt` returns RC 1, and the new `.rc != 0` logic correctly triggers the warning and includes it in the `warning_facts` summary.
* **Scenario B (Existing partition):** Confirmed that the task is skipped as expected when `.rc == 0`.