### PR TITLE
fixes 4.1.5 loop so all setting does not fail

### DIFF
--- a/tasks/section_4/cis_4.1.x.yml
+++ b/tasks/section_4/cis_4.1.x.yml
@@ -112,7 +112,7 @@
         direction: out
         proto: "{{ item.proto }}"
         to_port: '{{ item.port }}'
-      loop: "{{ ubtu22cis_ufw_allow_out_ports }}"
+      loop: "{{ ubtu22cis_ufw_allow_out_ports if ubtu22cis_ufw_allow_out_ports != 'all' else [] }}"
       loop_control:
         label: "{{ item.port }}"
       notify: Reload ufw


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
fixes 4.1.5 loop so "all" setting does not fail

**Issue Fixes:**
fixes 4.1.5 loop so "all" setting does not fail

**Enhancements:**
fixes 4.1.5 loop so "all" setting does not fail

**How has this been tested?:**
tested locally
