### PR TITLE
fix(rule-4.1.4): handle allow out ports set to 'all' correctly

### DIFF
--- a/tasks/section_4/cis_4.1.x.yml
+++ b/tasks/section_4/cis_4.1.x.yml
@@ -78,7 +78,7 @@
         direction: out
         proto: "{{ item.proto }}"
         to_port: '{{ item.port }}'
-      loop: "{{ ubtu22cis_ufw_allow_out_ports }}"
+      loop: "{{ ubtu22cis_ufw_allow_out_ports if ubtu22cis_ufw_allow_out_ports != 'all' else [] }}"
       loop_control:
         label: "{{ item.port }}"
       notify: Reload ufw


### PR DESCRIPTION
## Overall Review of Changes:

Changed `tasks/section_4/cis_4.1.x.yml` so the loop in the 4.1.5 "Custom ports" task uses an empty list when ubtu22cis_ufw_allow_out_ports == 'all', instead of looping over the raw value.

## Issue Fixes:

**Closes:** https://github.com/ansible-lockdown/UBUNTU22-CIS/issues/328

## Enhancements:

N/A

## How has this been tested?:

Local image builder

