### PR TITLE
Remove notify attribute in cis2.1.10 block

### DIFF
--- a/tasks/section_2/cis_2.1.x.yml
+++ b/tasks/section_2/cis_2.1.x.yml
@@ -315,7 +315,6 @@
     - nis
     - rule_2.1.10
     - NIST800-53R5_CM-7
-  notify: Systemd daemon reload
   block:
     - name: "2.1.10 | PATCH | Ensure nis server services are not in use | Remove package"
       when:

--- a/tasks/section_5/cis_5.1.x.yml
+++ b/tasks/section_5/cis_5.1.x.yml
@@ -191,7 +191,6 @@
     - NIST800-53R5_CM-7
     - NIST800-53R5_IA-5
     - rule_5.1.7
-  notify: Restart sshd
   block:
     - name: "5.1.7 | PATCH | Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured | Add line in sshd_config for ClientAliveInterval"
       ansible.builtin.lineinfile:
@@ -206,6 +205,7 @@
         regexp: '^ClientAliveCountMax'
         line: "ClientAliveCountMax {{ ubtu22cis_sshd_clientalivecountmax }}"
         validate: sshd -t -f %s
+      notify: Restart sshd
 
 - name: "5.1.8 | PATCH | Ensure sshd DisableForwarding is enabled"
   when: ubtu22cis_rule_5_1_8


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
Fixes the following runtime error:

```
ERROR: 'notify' is not a valid attribute for a Block
```

**Issue Fixes:**
N/A

**Enhancements:**
N/A

**How has this been tested?:**
N/A

